### PR TITLE
chore: Harden vagrant datapass provisionning

### DIFF
--- a/inventories/development/hosts
+++ b/inventories/development/hosts
@@ -4,5 +4,8 @@ datapass-development.particulier-infra.api.gouv.fr
 [datapass-back]
 datapass-development.particulier-infra.api.gouv.fr
 
+[datapass]
+datapass-development.particulier-infra.api.gouv.fr
+
 [api-auth]
 auth-development.particulier-infra.api.gouv.fr


### PR DESCRIPTION
Does not work because of missing host `datapass` (default host name in
Vagrantfile) in inventories.

The error message:

```
[WARNING: Could not match supplied host pattern, ignoring: datapass
ERROR! Specified hosts and/or --limit does not match any hosts
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.]
```