### PR TITLE
Build frontend in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Archive build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.env }}-build
+          name: ${{ matrix.env }}-${{ github.sha }}-build
           path: |
             signup-front/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,19 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "16.x"
-      - run: npm ci
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - run: npm install
       - run: npm run lint
       - run: npm run test
       - run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,19 @@ jobs:
     defaults:
       run:
         working-directory: signup-front
+    strategy:
+      matrix:
+        include:
+          - env: staging
+            back_host: https://back.datapass-staging.api.gouv.fr
+            api_gouv_host: https://www-staging.api.gouv.fr
+            piwik_url: ""
+            piwki_site_id: ""
+          - env: production
+            back_host: https://back.datapass.api.gouv.fr
+            api_gouv_host: https://api.gouv.fr
+            piwik_url: https://stats.data.gouv.fr
+            piwki_site_id: "53"
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 16.x
@@ -32,5 +45,13 @@ jobs:
       - run: npm run build
         env:
           REACT_APP_NODE_ENV: production
-          REACT_APP_BACK_HOST: https://back.datapass-staging.api.gouv.fr
-          REACT_APP_API_GOUV_HOST: https://www-staging.api.gouv.fr
+          REACT_APP_BACK_HOST: ${{ matrix.back_host }}
+          REACT_APP_API_GOUV_HOST: ${{ matrix.api_gouv_host }}
+          REACT_PIWIK_URL: ${{ matrix.piwik_url }}
+          REACT_PIWIK_SITE_ID: ${{ matrix.piwki_site_id }}
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.env }}-build
+          path: |
+            signup-front/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Frontend build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: signup-front
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build
+        env:
+          REACT_APP_NODE_ENV: production
+          REACT_APP_BACK_HOST: https://back.datapass-staging.api.gouv.fr
+          REACT_APP_API_GOUV_HOST: https://www-staging.api.gouv.fr


### PR DESCRIPTION
# Why?

The aim is to speed up the deployments.

The CI job tests that the code is valid with the `lint` and `test` scripts, then builds the frontend files and creates a downloadable archive exposed as a Github action artifact.

Two artifacts are built, one for the staging environment, one for the production environment.

Theses two environments differ by the env variable that are injected in the bundle, to control the external urls the bundled app calls when run from a browser.

# Next steps

Once this PR is merged, the deployment scripts can be updated in order to retrieve the artifacts when deploying the frontend application.