### PR TITLE
Deploy frontend from github action artifacts

### DIFF
--- a/configure.yml
+++ b/configure.yml
@@ -115,11 +115,6 @@
     - role: react-app
       app_service_name: signup-front
       server_name: "{{ front_domain_name }}"
-      env_var:
-        BACK_HOST: "{{ back_host }}"
-        PIWIK_URL: "{{ piwik_url | default('') }}"
-        PIWIK_SITE_ID: "{{ piwik_site_id | default('') }}"
-        API_GOUV_HOST: "{{ api_gouv_host }}"
       permanent_redirect_rules:
         - source_pattern: "= /api-impot-particulier"
           destination_path: "/api-impot-particulier-fc-sandbox"

--- a/deploy.yml
+++ b/deploy.yml
@@ -2,25 +2,25 @@
   vars:
     ansible_user: "{{ app_user }}"
   tasks:
-  - name: deploy front
-    script: ./scripts/deploy.sh signup-front
-    tags:
-    - front
+    - name: deploy front
+      script: ./scripts/deploy-static-app.sh signup-front
+      tags:
+        - front
 
 - hosts: datapass-back
   vars:
     ansible_user: "{{ app_user }}"
   tasks:
-  - name: deploy back
-    script: ./scripts/deploy.sh signup-back
-    tags:
-    - back
+    - name: deploy back
+      script: ./scripts/deploy-server-app.sh signup-back
+      tags:
+        - back
 
 - hosts: api-auth
   vars:
     ansible_user: "{{ app_user }}"
   tasks:
-  - name: deploy api-auth
-    script: ./scripts/deploy.sh api-auth
-    tags:
-    - api-auth
+    - name: deploy api-auth
+      script: ./scripts/deploy-server-app.sh api-auth
+      tags:
+        - api-auth

--- a/deploy.yml
+++ b/deploy.yml
@@ -3,7 +3,7 @@
     ansible_user: "{{ app_user }}"
   tasks:
     - name: deploy front
-      script: ./scripts/deploy-static-app.sh signup-front
+      script: "./scripts/deploy-static-app.sh signup-front {{ github_access_token }} {{ target_deploy_env }}"
       tags:
         - front
 

--- a/roles/react-app/tasks/main.yml
+++ b/roles/react-app/tasks/main.yml
@@ -9,14 +9,6 @@
     - /opt/apps
     - "/opt/apps/{{app_service_name}}"
 
-- name: copy configuration file
-  template:
-    src: service.conf.j2
-    dest: "/etc/{{app_service_name}}.conf"
-    owner: "{{ app_user }}"
-    group: "{{ app_user }}"
-    mode: 0400
-
 - name: configure nginx
   template:
     src: server.conf.j2

--- a/roles/react-app/templates/server.conf.j2
+++ b/roles/react-app/templates/server.conf.j2
@@ -13,7 +13,7 @@ server {
   ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4";
 
   location / {
-    root /opt/apps/{{app_service_name}}/current/build;
+    root /opt/apps/{{app_service_name}}/current;
   }
 {% if permanent_redirect_rules is defined %}
 {% for redirect_rule in permanent_redirect_rules %}

--- a/roles/react-app/templates/service.conf.j2
+++ b/roles/react-app/templates/service.conf.j2
@@ -1,5 +1,0 @@
-NODE_ENV={{ node_env }}
-
-{% for key,value in env_var.items() %}
-{{key}}={{value}}
-{% endfor %}

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -73,8 +73,10 @@ echo "$(logPrefix) Linking new deployment..."
 
 
 
-echo "$(logPrefix) Restarting service..."
-sudo /bin/systemctl restart ${APP_NAME}
+if [ -e /etc/systemd/system/${APP_NAME}.service ]; then
+    echo "$(logPrefix) Restarting service..."
+    sudo /bin/systemctl restart ${APP_NAME}
+fi
 if [ -e Gemfile ]; then
     sudo /bin/systemctl restart sidekiq-${APP_NAME}
 fi

--- a/scripts/deploy-server-app.sh
+++ b/scripts/deploy-server-app.sh
@@ -66,8 +66,6 @@ if [ -e package.json ]; then
       rsync -a $PREVIOUS_NODE_MODULE_PATH node_modules
     fi
     npm i
-    export GENERATE_SOURCEMAP=false
-    export DISABLE_ESLINT_PLUGIN=true
     npm run build
 fi
 
@@ -77,10 +75,8 @@ if [ -h ${APP_PATH}/current ]; then
 fi
 ln -s ${RELEASES_PATH} ${APP_PATH}/current
 
-if [ -e /etc/systemd/system/${APP_NAME}.service ]; then
-    echo "$(logPrefix) Restarting service..."
-    sudo /bin/systemctl restart ${APP_NAME}
-fi
+echo "$(logPrefix) Restarting service..."
+sudo /bin/systemctl restart ${APP_NAME}
 
 if [ -e Gemfile ]; then
     echo "$(logPrefix) Restarting sidekiq service..."

--- a/scripts/deploy-static-app.sh
+++ b/scripts/deploy-static-app.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+set -x
+
+{
+logPrefix(){
+  echo "$(date --iso-8601=seconds) - $APP_NAME -"
+}
+
+if [ -z $1 ]; then
+    echo "$(logPrefix) Error: You must provide the application name as an argument. Ex: ./scripts/deploy.sh signup-front"
+    exit 1
+fi
+
+APP_NAME=$1
+APP_VERSION=master
+echo "$(logPrefix) Deploying $APP_NAME..."
+
+echo "$(logPrefix) Preparing installation..."
+ROOT_PATH=/opt/apps
+APP_PATH=${ROOT_PATH}/${APP_NAME}
+TIMESTAMP=$(date +'%Y%m%d%H%M%S')
+RELEASES_PATH=${APP_PATH}/releases/${TIMESTAMP}
+mkdir -p ${APP_PATH}/releases
+
+echo "$(logPrefix) Fetching archive..."
+cd ${APP_PATH}
+curl -f -L https://github.com/betagouv/datapass/archive/${APP_VERSION}.tar.gz --output datapass-${APP_VERSION}.tar.gz
+
+echo "$(logPrefix) Unpacking..."
+tar -xzf datapass-${APP_VERSION}.tar.gz
+mv datapass-${APP_VERSION}/${APP_NAME}/ ${RELEASES_PATH}
+rm -rf datapass-${APP_VERSION}/
+rm datapass-${APP_VERSION}.tar.gz
+
+echo "$(logPrefix) Installing..."
+cd ${RELEASES_PATH}
+export $(cat /etc/${APP_NAME}.conf | xargs)
+
+if [ -e package.json ]; then
+    PREVIOUS_NODE_MODULE_PATH=$(ls -r -d ${APP_PATH}/releases/* | tail -n +2 | head -n 1)/node_modules
+    if [ -d "$PREVIOUS_NODE_MODULE_PATH" ]; then
+      echo "$(logPrefix) Copying node modules from previous release..."
+      rsync -a $PREVIOUS_NODE_MODULE_PATH node_modules
+    fi
+    npm i
+    export GENERATE_SOURCEMAP=false
+    export DISABLE_ESLINT_PLUGIN=true
+    npm run build
+fi
+
+echo "$(logPrefix) Linking new deployment..."
+if [ -h ${APP_PATH}/current ]; then
+    rm ${APP_PATH}/current
+fi
+ln -s ${RELEASES_PATH} ${APP_PATH}/current
+
+echo "$(logPrefix) Removing old releases..."
+cd ${APP_PATH}/releases
+ls . | sort -r | tail -n +6 | xargs rm -rf
+
+echo "$(logPrefix) Deployment of $APP_NAME successfully completed!"
+
+exit 0
+} >> /opt/apps/apps-deployment.log

--- a/signup-front/signup-front.conf
+++ b/signup-front/signup-front.conf
@@ -1,7 +1,0 @@
-NODE_ENV=production
-ACCESS_LOG_PATH=/var/log/signup-front/access.log
-
-BACK_HOST=https://back.datapass-development.api.gouv.fr
-PIWIK_URL=
-PIWIK_SITE_ID=
-API_GOUV_HOST=https://www-staging.api.gouv.fr


### PR DESCRIPTION
# Why

Now that Github actions bundles up the frontend into action artifacts, these artifacts can be downloaded to be deployed right away on the desired environement.

The script uses two new ansible variables that will be defined in the secrets repository:
- `github_access_token`: a token with the `public_repo` scope, needed to download the artifacts
- `target_deploy_env`: one of `staging` or `production`, will determine which build artifact is used on the environement

