### PR TITLE
Fix piwik integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
           REACT_APP_NODE_ENV: production
           REACT_APP_BACK_HOST: ${{ matrix.back_host }}
           REACT_APP_API_GOUV_HOST: ${{ matrix.api_gouv_host }}
-          REACT_PIWIK_URL: ${{ matrix.piwik_url }}
-          REACT_PIWIK_SITE_ID: ${{ matrix.piwki_site_id }}
+          REACT_APP_PIWIK_URL: ${{ matrix.piwik_url }}
+          REACT_APP_PIWIK_SITE_ID: ${{ matrix.piwki_site_id }}
       - name: Archive build artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
# Why

Piwik was not working anymore since the Github Action build feature.

This is due to bad env var names, CRA requires variables to start with `REACT_APP_`, the faulty names started with `REACT_`.