### PR TITLE
chore: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/signup-back"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/signup-front"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Parce qu'être à jour c'est bien askip.