### PR TITLE
[feat] Continuous deployment

### DIFF
--- a/configure.yml
+++ b/configure.yml
@@ -188,3 +188,10 @@
         - "{{ retool_ssh_key }}"
       when: retool_ssh_key is defined
       tags: retool
+
+- hosts: datapass-front
+  become: true
+  roles:
+    - role: continuous-deployment
+      when: target_deploy_env is defined
+      tags: continuous-deployment

--- a/roles/continuous-deployment/defaults/main.yml
+++ b/roles/continuous-deployment/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+webhook_port: "9000"
+
+webhook_version: "2.7.0"
+webhook_checksum: "md5:8bb63914f4ead672ff43191e91b0249f"
+
+webhook_secret: supersecret
+build_job_name: "build"

--- a/roles/continuous-deployment/handlers/main.yml
+++ b/roles/continuous-deployment/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart service webhook
+  service:
+    name: webhook
+    state: restarted

--- a/roles/continuous-deployment/tasks/main.yml
+++ b/roles/continuous-deployment/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Copy webhook webhooks.json file
+  become: true
+  template:
+    src: templates/webhooks.json.j2
+    dest: "/etc/webhooks.json"
+    owner: "{{ app_user }}"
+    group: "{{ app_user }}"
+    mode: u=rw,g=r,o=r
+
+- name: check if webhook file already exists (to allow download bypass - necessary if behind firewall)
+  stat:
+    path: /tmp/webhook.tar.gz
+  register: tarball
+
+- name: Download file with check (md5)
+  tags: download
+  get_url:
+    url: "https://github.com/adnanh/webhook/releases/download/{{ webhook_version }}/webhook-linux-amd64.tar.gz"
+    dest: "/tmp/webhook.tar.gz"
+    checksum: "{{ webhook_checksum }}"
+  when: not tarball.stat.exists
+
+- name: Unarchive a file with extra options
+  tags: download
+  become: true
+  unarchive:
+    src: /tmp/webhook.tar.gz
+    dest: /usr/local/bin
+    remote_src: true
+    extra_opts:
+      - --strip-components=1
+
+- name: Install systemd file for webhook
+  template:
+    src: templates/webhook.service.j2
+    dest: /etc/systemd/system/webhook.service
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+
+- name: Enable and start webhook service
+  service:
+    name: webhook
+    enabled: true
+    state: started
+
+- name: Copy server apps deploy scripts
+  copy:
+    dest: "~/deploy-server-app.sh"
+    src: "{{ inventory_dir }}/../../scripts/deploy-server-app.sh"
+    mode: 0770
+  become: yes
+  become_user: "{{ app_user }}"
+
+- name: Copy static apps deploy scripts
+  copy:
+    dest: "~/deploy-static-app.sh"
+    src: "{{ inventory_dir }}/../../scripts/deploy-static-app.sh"
+    mode: 0770
+  become: yes
+  become_user: "{{ app_user }}"

--- a/roles/continuous-deployment/tasks/main.yml
+++ b/roles/continuous-deployment/tasks/main.yml
@@ -6,7 +6,7 @@
     dest: "/etc/webhooks.json"
     owner: "{{ app_user }}"
     group: "{{ app_user }}"
-    mode: u=rw,g=r,o=r
+    mode: 0644
 
 - name: check if webhook file already exists (to allow download bypass - necessary if behind firewall)
   stat:
@@ -35,9 +35,9 @@
   template:
     src: templates/webhook.service.j2
     dest: /etc/systemd/system/webhook.service
-    owner: root
-    group: root
-    mode: u=rw,g=r,o=r
+    owner: "{{ app_user }}"
+    group: "{{ app_user }}"
+    mode: 0400
 
 - name: Enable and start webhook service
   service:
@@ -48,7 +48,7 @@
 - name: Copy server apps deploy scripts
   copy:
     dest: "~/deploy-server-app.sh"
-    src: "{{ inventory_dir }}/../../scripts/deploy-server-app.sh"
+    src: "{{ playbook_dir }}/scripts/deploy-server-app.sh"
     mode: 0770
   become: yes
   become_user: "{{ app_user }}"
@@ -56,7 +56,7 @@
 - name: Copy static apps deploy scripts
   copy:
     dest: "~/deploy-static-app.sh"
-    src: "{{ inventory_dir }}/../../scripts/deploy-static-app.sh"
-    mode: 0770
+    src: "{{ playbook_dir }}/scripts/deploy-static-app.sh"
+    mode: 0700
   become: yes
   become_user: "{{ app_user }}"

--- a/roles/continuous-deployment/templates/webhook.service.j2
+++ b/roles/continuous-deployment/templates/webhook.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Webhooks
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User={{ app_user }}
+Restart=on-failure
+RestartSec=5
+ExecStart=/usr/local/bin/webhook -verbose -hotreload -hooks /etc/webhooks.json -port {{ webhook_port }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/continuous-deployment/templates/webhooks.json.j2
+++ b/roles/continuous-deployment/templates/webhooks.json.j2
@@ -1,0 +1,120 @@
+[
+    {
+        "id": "deploy-datapass-backend",
+        "execute-command": "/home/{{ app_user }}/deploy-server-app.sh",
+        "command-working-directory": "/home/{{ app_user }}",
+        "pass-arguments-to-command": [
+            {
+                "source": "string",
+                "name": "signup-back"
+            }
+        ],
+        "trigger-rule": {
+            "and": [
+                {
+                    "match": {
+                        "type": "payload-hash-sha1",
+                        "secret": "{{ webhook_secret }}",
+                        "parameter": {
+                            "source": "header",
+                            "name": "X-Hub-Signature"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "value",
+                        "value": "completed",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "action"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "regex",
+                        "regex": "{{ build_job_name }} \\({{ target_deploy_env }}.*",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "check_run.name"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "value",
+                        "value": "master",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "check_run.check_suite.head_branch"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "id": "deploy-datapass-frontend",
+        "execute-command": "/home/{{ app_user }}/deploy-static-app.sh",
+        "command-working-directory": "/home/{{ app_user }}",
+        "pass-arguments-to-command": [
+            {
+                "source": "string",
+                "name": "signup-front"
+            },
+            {
+                "source": "string",
+                "name": "{{ github_access_token }}"
+            },
+            {
+                "source": "string",
+                "name": "{{ target_deploy_env }}"
+            }
+        ],
+        "trigger-rule": {
+            "and": [
+                {
+                    "match": {
+                        "type": "payload-hash-sha1",
+                        "secret": "{{ webhook_secret }}",
+                        "parameter": {
+                            "source": "header",
+                            "name": "X-Hub-Signature"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "value",
+                        "value": "completed",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "action"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "regex",
+                        "regex": "{{ build_job_name }} \\({{ target_deploy_env }}.*",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "check_run.name"
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "type": "value",
+                        "value": "master",
+                        "parameter": {
+                            "source": "payload",
+                            "name": "check_run.check_suite.head_branch"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/roles/ufw/tasks/main.yml
+++ b/roles/ufw/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name : Enable UFW and close all ports (DO NOT INTERRUPT!!!)
+- name: Enable UFW and close all ports (DO NOT INTERRUPT!!!)
   ufw:
     state: enabled
     policy: deny
 # NB. if the playbook stop here you will loss access to your server.
 
-- name : allow all access to allowed tcp
+- name: allow all access to allowed tcp
   ufw:
     rule: allow
     port: "{{ item }}"
@@ -14,3 +14,4 @@
     - 22
     - 80
     - 443
+    - 9000


### PR DESCRIPTION
# What

Now that the frotend assets are built automatically, it is time to move to the next step and setup a continuous deployment workflow.
The aim is to use Github webhooks in order to react to the repository events and deploy applications when necessary.

# How

By installing [a webhook utility](https://github.com/adnanh/webhook) on the servers, one can react to Github events, and detect when it is time to run the deployment scripts.
The tool runs as an http server listening on port 9000.
The trafic does **not** need to be encrypted with HTTPS since the github events payloads are public, and it would be tedious to run the webhook utility behind a reverse proxy (but still possible).

# Configuration

- on Github: to use the webhook utility, one must setup a [webhook](https://github.com/betagouv/datapass/settings/hooks) listening to the `check_run` events. The server listens to this particulier type of events since it's the only way to determine when a specific job is completed successfully, the asset build job here. When setting up the webhook, a secret is asked, this secret can be randomly chosen
- in the provisioning repository, this secret must be set as the `webhook_secret` variable

# Caveats

- the frontend assets build job is taken as a reference as when a deployment is necessary
- this job must keep the [`build`](https://github.com/betagouv/datapass/blob/master/.github/workflows/frontend-build.yml#L9) name, any change to this name must be reflected through the `build_job_name` ansible variable, set up as a default role variable for the `continuous-deployment` role

# Next steps (in another PR)

- setup a manual deploy workflow for production

# Nice to have

- Run the webhook utility behind the server's reverse proxy in order to encrypt the trafic betwwen Github and the server
  - add a new subdomain for the webhook, such as hooks.datapass.api.gouv.fr
  - add an entry to nginx
  - update the webhooks configuration on Github
- Update the deployment scripts to call the Github Rest API once the deployment is successful, to create a [Github deployment](https://docs.github.com/en/rest/reference/repos#deployments) and give feedback to the developer