### PR TITLE
chore: add simple linter/security checker in back CI

### DIFF
--- a/.github/workflows/back.yml
+++ b/.github/workflows/back.yml
@@ -1,4 +1,4 @@
-name: Backend CI
+name: Backend CI (Tests, linter and security)
 
 on:
   push:
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: Tests (RSpec)
+    name: Run
     runs-on: ubuntu-18.04
     defaults:
       run:
@@ -79,6 +79,14 @@ jobs:
         run: |
           bundler exec rails db:create RAILS_ENV=test
           bundler exec rails db:schema:load RAILS_ENV=test
+
+      - name: Run StandardRB (linter)
+        run: |
+          bundle exec standardrb
+
+      - name: Run Brakeman (security)
+        run: |
+          bundle exec brakeman
 
       - name: Run tests & publish coverage
         uses: paambaati/codeclimate-action@v2.7.5

--- a/.github/workflows/back.yml
+++ b/.github/workflows/back.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: Run
+    name: Tests (RSpec)
     runs-on: ubuntu-18.04
     defaults:
       run:


### PR DESCRIPTION
Readd some basic checks for lint/security (no more GA because of strange issues), at least it fails the backend CI with these checks