### PR TITLE
[feature] Manual deployment workflow

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,0 +1,10 @@
+name: Manually deploy the application
+
+on: workflow_dispatch
+
+jobs:
+  manual_deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Nothing to do here, workflow dispatch will trigger the deployment via the webhook"


### PR DESCRIPTION
# Why?

In order to be able to manually trigger a deployment, there must be a workflow to run to trigger a webhook call from Github to the application server.