### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -82,11 +82,9 @@ jobs:
       - name: Setup private SSH deployment key
         run: |
           mkdir -p ~/.ssh/
-          echo "$SSH_PRIVATE_KEY" > ./deployment.key
-          sudo chmod 600 ./deployment.key
+          echo "$SSH_PRIVATE_KEY" > ../private.key
+          sudo chmod 600 ../private.key
+          ssh-keyscan -t rsa -H "$SSH_HOST" > ~/.ssh/known_hosts
         shell: bash
-      - name: Add target ssh host signature to known hosts
-        run: |
-          ssh-keyscan -t rsa -H "$SSH_HOST" >> ~/.ssh/known_hosts
       - name: Deploy application
-        run: ssh -i ./deployment.key "$APP_USER@$SSH_HOST"
+        run: ssh -i ../private.key "$APP_USER@$SSH_HOST"

--- a/configure.yml
+++ b/configure.yml
@@ -189,8 +189,19 @@
       when: retool_ssh_key is defined
       tags: retool
 
-- hosts: all
+- hosts: datapass-back
   become: true
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/datapass-back.yml"
+  roles:
+    - role: continuous-deployment
+      when: github_action_ssh_key is defined
+      tags: continuous-deployment
+
+- hosts: datapass-front
+  become: true
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/datapass-front.yml"
   roles:
     - role: continuous-deployment
       when: github_action_ssh_key is defined


### PR DESCRIPTION
# Context

The deployment is failing because no deployment SSH key gets accepted on the different environments.

# Why

- there was an issue with the private key being saved in the current directory, don't know why
- after this change, the staging frontend deployment key was still being rejected:
  - after a small investigation, I noticed that on the staging env, where there should be two deployment ssh keys (frontend and backend), only the frontend was present
  - I first thought it was because of the `all` hosts selector in the `configure.yml` playbook, which led to resolve only one host and thus one group (the first matching one, `datapass-back`), taking only into account the `datapass-back.yml` var file
  - To verify this hypothesis, I ran the playbook with a more specific host selector, `datapass-front`. THIS DIDN'T SOLVE THE PROBLEM!!! The variable in the `datapass-front.yml` was not used, instead Ansible was using the one in `datapass-back.yml`
  - I then [learnt](https://serverfault.com/questions/966019/ansible-same-host-on-different-groups-with-group-vars) that Ansible first resolves the hostname based on the group specified in the `hosts` selector in the playbook, then attaches groups to this hostname, and resolves the group_vars files. So two definitions of the same variable, in two matching groups files, will conflict. Based on this article, the trick is to specify which group_vars file is used
  
Awesome Ansible learning today!