### PR TITLE
Creation form hubee dila

### DIFF
--- a/signup-back/app/bridges/hubee_portail_dila_bridge.rb
+++ b/signup-back/app/bridges/hubee_portail_dila_bridge.rb
@@ -1,0 +1,2 @@
+class HubeePortailDilaBridge < HubeePortailBridge
+end

--- a/signup-back/app/models/enrollment/hubee_portail_dila.rb
+++ b/signup-back/app/models/enrollment/hubee_portail_dila.rb
@@ -1,0 +1,2 @@
+class Enrollment::HubeePortailDila < Enrollment::HubeePortail
+end

--- a/signup-back/app/policies/enrollment/hubee_portail_dila_policy.rb
+++ b/signup-back/app/policies/enrollment/hubee_portail_dila_policy.rb
@@ -1,0 +1,23 @@
+class Enrollment::HubeePortailDilaPolicy < EnrollmentPolicy
+  def permitted_attributes
+    res = []
+
+    res.concat([
+      :target_api,
+      :organization_id,
+      :intitule,
+      :cgu_approved,
+      :dpo_is_informed,
+      scopes: [
+        :aec,
+        :ddpacs,
+        :rco,
+        :dhtour,
+        :jcc
+      ],
+      team_members_attributes: [:id, :type, :family_name, :given_name, :email, :phone_number, :job]
+    ])
+
+    res
+  end
+end

--- a/signup-back/config/data_providers.yml
+++ b/signup-back/config/data_providers.yml
@@ -123,6 +123,11 @@ hubee_portail:
   support_email: contact@api.gouv.fr
   mailer: *shared_mailer
 
+hubee_portail_dila:
+  label: Portail HubEE
+  support_email: contact@api.gouv.fr
+  mailer: *shared_mailer
+
 api_pro_sante_connect:
   label: API Pro Santé Connect
   support_email: contact@api.gouv.fr

--- a/signup-front/src/components/organisms/form-sections/hubee-sections/DemarcheEnLigneSection.js
+++ b/signup-front/src/components/organisms/form-sections/hubee-sections/DemarcheEnLigneSection.js
@@ -3,15 +3,16 @@ import { FormContext } from '../../../templates/Form';
 import { ScrollablePanel } from '../../Scrollable';
 import CheckboxInput from '../../../atoms/inputs/CheckboxInput';
 import ExpandableQuote from '../../../molecules/ExpandableQuote';
+import { isEmpty } from 'lodash';
 
 const SECTION_LABEL = 'Démarches en ligne';
 const SECTION_ID = encodeURIComponent(SECTION_LABEL);
 
-export const DemarcheEnLigneSection = () => {
+export const DemarcheEnLigneSection = ({ demarchesHubee = [] }) => {
   const {
     disabled,
     onChange,
-    enrollment: { scopes: { cert_dc = false } = {} },
+    enrollment: { scopes = {} },
   } = useContext(FormContext);
 
   return (
@@ -19,20 +20,30 @@ export const DemarcheEnLigneSection = () => {
       <h2>
         Démarches en ligne auxquelles vous souhaitez abonner votre commune
       </h2>
-      <ExpandableQuote title=" En quoi consiste cette démarche ?">
+      <ExpandableQuote
+        title={`En quoi consiste ${
+          demarchesHubee.length === 1 ? 'cette démarche' : 'ces démarches'
+        } ?`}
+      >
         <>
-          Ce service donne la possibilité de recevoir par voie électronique le
-          volet administratif du certificat de décès lorsque le médecin rédige
-          le certificat de décès au moyen de l’application « CertDc ».
+          {!isEmpty(demarchesHubee) &&
+            demarchesHubee.map(({ id, label, description }) => (
+              <p key={id}>
+                <b>{label} :</b> {description}
+              </p>
+            ))}
         </>
       </ExpandableQuote>
-      <CheckboxInput
-        name="scopes.cert_dc"
-        value={cert_dc}
-        label="Certificat de décès (CertDc)"
-        onChange={onChange}
-        disabled={disabled}
-      />
+      {!isEmpty(demarchesHubee) &&
+        demarchesHubee.map(({ id, label }) => (
+          <CheckboxInput
+            name={`scopes.${id}`}
+            value={scopes[id]}
+            label={label}
+            onChange={onChange}
+            disabled={disabled}
+          />
+        ))}
     </ScrollablePanel>
   );
 };

--- a/signup-front/src/config/data-provider-parameters.tsx
+++ b/signup-front/src/config/data-provider-parameters.tsx
@@ -72,7 +72,7 @@ export const DATA_PROVIDER_PARAMETERS: { [k: string]: DataProviderParameter } =
       component: HubeePortail,
     },
     hubee_portail_dila: {
-      label: 'Portail HubEE',
+      label: 'Portail HubEE - Démarches DILA',
       icon: 'logo-hubee.png',
       email: 'support@hubee.numerique.gouv.fr',
       component: HubeePortailDila,

--- a/signup-front/src/config/data-provider-parameters.tsx
+++ b/signup-front/src/config/data-provider-parameters.tsx
@@ -35,6 +35,7 @@ import AidantsConnect from '../pages/AidantsConnect';
 import ApiServiceNational from '../pages/ApiServiceNational';
 import ApiTiersDePrestation from '../pages/UrssafPages/ApiTiersDePrestation';
 import HubeePortail from '../pages/HubeePortail';
+import HubeePortailDila from '../pages/HubeePortailDila';
 import ApiProSanteConnect from '../pages/ApiProSanteConnect';
 import ApiDeclarationAutoEntrepreneur from '../pages/UrssafPages/ApiDeclarationAutoEntrepreneur';
 import ApiIndemnitesJournalieresCnam from '../pages/ApiIndemnitesJournalieresCnam';
@@ -65,10 +66,16 @@ export const DATA_PROVIDER_PARAMETERS: { [k: string]: DataProviderParameter } =
       component: AidantsConnect,
     },
     hubee_portail: {
-      label: 'Portail HubEE',
+      label: 'Portail HubEE - Démarche CertDC',
       icon: 'logo-hubee.png',
       email: 'support@hubee.numerique.gouv.fr',
       component: HubeePortail,
+    },
+    hubee_portail_dila: {
+      label: 'Portail HubEE',
+      icon: 'logo-hubee.png',
+      email: 'support@hubee.numerique.gouv.fr',
+      component: HubeePortailDila,
     },
     franceconnect: {
       label: 'FranceConnect',

--- a/signup-front/src/pages/HubeePortail.js
+++ b/signup-front/src/pages/HubeePortail.js
@@ -26,11 +26,26 @@ const initialContacts = {
         utilisateurs.
       </>
     ),
+    displayIndividualEmailLabel: true,
   },
   responsable_traitement: null,
   delegue_protection_donnees: null,
   responsable_technique: null,
 };
+
+const demarchesHubee = [
+  {
+    id: 'cert_dc',
+    label: 'CertDc - Certificat de décès',
+    description: (
+      <>
+        Ce service donne la possibilité de recevoir par voie électronique le
+        volet administratif du certificat de décès lorsque le médecin rédige le
+        certificat de décès au moyen de l’application « CertDc ».
+      </>
+    ),
+  },
+];
 
 const target_api = 'hubee_portail';
 
@@ -42,7 +57,7 @@ const HubeePortail = () => (
   >
     <OrganisationSection />
     <IntituleInitializerSection value="Abonnement au portail HubEE" />
-    <DemarcheEnLigneSection />
+    <DemarcheEnLigneSection demarchesHubee={demarchesHubee} />
     <ÉquipeSection initialContacts={initialContacts} />
     <CguSection cguLink="/docs/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf" />
   </Form>

--- a/signup-front/src/pages/HubeePortailDila.js
+++ b/signup-front/src/pages/HubeePortailDila.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import Form from '../components/templates/Form';
+import OrganisationSection from '../components/organisms/form-sections/OrganisationSection';
+import DemarcheEnLigneSection from '../components/organisms/form-sections/hubee-sections/DemarcheEnLigneSection';
+import ÉquipeSection from '../components/organisms/form-sections/ÉquipeSection';
+import CguSection from '../components/organisms/form-sections/CguSection';
+import { DATA_PROVIDER_PARAMETERS } from '../config/data-provider-parameters';
+import IntituleInitializerSection from '../components/organisms/form-sections/hubee-sections/IntituleInitializerSection';
+
+const initialContacts = {
+  demandeur: {
+    header: 'Demandeur',
+    description: (
+      <>
+        <b>Le demandeur</b>, c’est vous, dépose la demande d’abonnement.
+      </>
+    ),
+    forceDisable: true,
+  },
+  responsable_metier: {
+    header: 'Responsable d’abonnement',
+    description: (
+      <>
+        <b>Le responsable d’abonnement</b> disposera des droits d’administration
+        sur le portail HubEE : gestion des abonnements et gestion des
+        utilisateurs.
+      </>
+    ),
+  },
+  responsable_traitement: null,
+  delegue_protection_donnees: null,
+  responsable_technique: null,
+};
+
+const target_api = 'hubee_portail_dila';
+
+const HubeePortailDila = () => (
+  <Form
+    target_api={target_api}
+    contactEmail={DATA_PROVIDER_PARAMETERS[target_api]?.email}
+    documentationUrl="https://www.numerique.gouv.fr/dinum/"
+  >
+    <OrganisationSection />
+    <IntituleInitializerSection value="Abonnement au portail HubEE" />
+    <DemarcheEnLigneSection />
+    <ÉquipeSection initialContacts={initialContacts} />
+    <CguSection cguLink="/docs/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf" />
+  </Form>
+);
+
+export default HubeePortailDila;

--- a/signup-front/src/pages/HubeePortailDila.js
+++ b/signup-front/src/pages/HubeePortailDila.js
@@ -26,12 +26,90 @@ const initialContacts = {
         utilisateurs.
       </>
     ),
+    displayIndividualEmailLabel: true,
   },
   responsable_traitement: null,
   delegue_protection_donnees: null,
   responsable_technique: null,
 };
 
+const demarchesHubee = [
+  {
+    id: 'aec',
+    label: 'AEC - Acte d’Etat Civil',
+    description: (
+      <>
+        Ce service donne la possibilité aux usagers d’effectuer sur internet
+        leurs demandes d’actes de naissance, de mariage, de décès.
+      </>
+    ),
+  },
+  {
+    id: 'ddpacs',
+    label:
+      'DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs',
+    description: (
+      <>
+        Ce service permet à des usagers souhaitant se pacser de compléter en
+        ligne les informations nécessaires à cette union (actuellement contenues
+        dans les Cerfa) et de télécharger leurs pièces justificatives (actes de
+        naissance convention spécifique de PACS le cas échéant). L’ensemble est
+        envoyé à la commune chargée de conclure le PACS (à savoir la mairie de
+        résidence commune des partenaires).
+      </>
+    ),
+  },
+  {
+    id: 'rco',
+    label: 'RCO - Recensement Citoyen Obligatoire',
+    description: (
+      <>
+        Ce service permet à un jeune de transmettre son dossier en ligne à la
+        mairie, sans déplacement et à tout moment de la journée. La commune peut
+        en retour envoyer l’attestation de recensement vers le porte-documents
+        sécurisé sur le compte personnel de l’usager. Tout français âgé de 16
+        ans doit spontanément se faire recenser auprès de sa mairie (ou auprès
+        de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à
+        la Journée Défense et Citoyenneté (JDC). Tous les jeunes français,
+        garçons et filles, sont concernés. Cette formalité est obligatoire pour
+        avoir le droit de se présenter aux concours et examens publics
+        (Baccalauréat, permis de conduire, etc.).
+      </>
+    ),
+  },
+  {
+    id: 'dhtour',
+    label: 'DHTOUR - Déclaration d’hébergement touristique',
+    description: (
+      <>
+        Ce service permet aux particuliers et professionnels de déclarer en
+        ligne un meublé de tourisme ou une chambre d’hôtes. Ce service peut être
+        proposé par les municipalités qui collectent la taxe de séjour
+        uniquement (métropoles de droit commun).
+      </>
+    ),
+  },
+  {
+    id: 'jcc',
+    label: 'JCC - Déclaration de Changement de Coordonnées',
+    description: (
+      <>
+        Ce service permet à un usager de déclarer rapidement et facilement un
+        changement d’adresse postale lors d’un déménagement ou d’une
+        modification administrative. Via ce service, l’usager peut également
+        procéder à la mise à jour de son adresse électronique, ses numéros de
+        téléphone fixe et de portable. Il peut ainsi signaler à sa commune son
+        changement de coordonnées. Tout nouvel arrivant a par ailleurs la
+        possibilité de préciser la composition de son foyer (nombre d’adultes et
+        d’enfants, âge des enfants). Tout opérateur de service, public ou privé
+        (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès
+        de la direction de l’information légale et administrative (DILA) qui en
+        étudiera la faisabilité juridique (demande réalisée via le portail du
+        Hub d’Échange de l’État).
+      </>
+    ),
+  },
+];
 const target_api = 'hubee_portail_dila';
 
 const HubeePortailDila = () => (
@@ -42,7 +120,7 @@ const HubeePortailDila = () => (
   >
     <OrganisationSection />
     <IntituleInitializerSection value="Abonnement au portail HubEE" />
-    <DemarcheEnLigneSection />
+    <DemarcheEnLigneSection demarchesHubee={demarchesHubee} />
     <ÉquipeSection initialContacts={initialContacts} />
     <CguSection cguLink="/docs/20210212_dinum_hubee_cgu_v2_1_0_version_site.pdf" />
   </Form>


### PR DESCRIPTION
Création du fichier du formulaire HubEE Dila. Quelques changements restent à faire, ils sont listés dans le ticket Trello mais je les remets ici : 

- "En quoi consiste cette démarche ?" devient "En quoi consiste ces démarches ?"

- Le contenu de ce cadre est :
"- AEC - Acte d'Etat Civil : Ce service donne la possibilité aux usagers d'effectuer sur internet leurs demandes d'actes de naissance, de mariage, de décès.
- DDPACS - Démarche en ligne de préparation à la conclusion d’un Pacs : Ce service permet à des usagers souhaitant se pacser de compléter en ligne les informations nécessaires à cette union (actuellement contenues dans les Cerfa) et de télécharger leurs pièces justificatives (actes de naissance convention spécifique de PACS le cas échéant). L'ensemble est envoyé à la commune chargée de conclure le PACS (à savoir la mairie de résidence commune des partenaires).
- RCO - Recensement Citoyen Obligatoire : Ce service permet à un jeune de transmettre son dossier en ligne à la mairie, sans déplacement et à tout moment de la journée. La commune peut en retour envoyer l'attestation de recensement vers le porte-documents sécurisé sur le compte personnel de l'usager. Tout français âgé de 16 ans doit spontanément se faire recenser auprès de sa mairie (ou auprès de son Consulat, lorsqu’il réside à l’étranger) en vue de participer à la Journée Défense et Citoyenneté (JDC). Tous les jeunes français, garçons et filles, sont concernés. Cette formalité est obligatoire pour avoir le droit de se présenter aux concours et examens publics (Baccalauréat, permis de conduire, etc…).
- DHTOUR - Déclaration d'hébergement touristique : Ce service permet aux particuliers et professionnels de déclarer en ligne un meublé de tourisme ou une chambre d'hôtes. Ce service peut être proposé par les municipalités qui collectent la taxe de séjour uniquement (métropoles de droit commun).
- JCC - Déclaration de Changement de Coordonnées : Ce service permet à un usager de déclarer rapidement et facilement un changement d'adresse postale lors d'un déménagement ou d'une modification administrative. Via ce service, l'usager peut également procéder à la mise à jour de son adresse électronique, ses numéros de téléphone fixe et de portable. Il peut ainsi signaler à sa commune son changement de coordonnées. Tout nouveau arrivant a par ailleurs la possibilité de préciser la composition de son foyer (nombre d'adultes et d'enfants, âge des enfants). Tout opérateur de service, public ou privé (téléphonie, énergie, etc.), peut faire une demande d’abonnement auprès de la direction de l’information légale et administrative (DILA) qui en étudiera la faisabilité juridique (demande réalisée via le portail du Hub d'Échange de l'État)."

- Ajouter le critère displayIndividualEmailLabel: true sur le mail du Responsable d'abonnement