### PR TITLE
feat: Prevent form to scroll when errors in Form completion.

### DIFF
--- a/frontend/src/Routes.js
+++ b/frontend/src/Routes.js
@@ -1,27 +1,32 @@
+import { isEmpty } from 'lodash';
 import React, { useLayoutEffect } from 'react';
 import {
   Route,
   Routes as ReactRouterRoutes,
   useLocation,
 } from 'react-router-dom';
+import { AuthRequired, useAuth } from './components/organisms/AuthContext';
+import FormRouter from './components/organisms/FormRouter';
+import Accessibilite from './components/templates/Accessibilite';
+import Admin from './components/templates/Admin';
+import CopyEnrollment from './components/templates/CopyEnrollment';
+import DataProviderList from './components/templates/DataProviderList';
+import Enrollment from './components/templates/Enrollment';
+import FAQ from './components/templates/Faq';
+import AdminEnrollmentList from './components/templates/InstructorEnrollmentList';
 import PublicEnrollmentList from './components/templates/PublicEnrollmentList';
 import Stats from './components/templates/Stats';
-import Accessibilite from './components/templates/Accessibilite';
-import { isEmpty } from 'lodash';
-import AdminEnrollmentList from './components/templates/InstructorEnrollmentList';
-import CopyEnrollment from './components/templates/CopyEnrollment';
-import Enrollment from './components/templates/Enrollment';
 import UserEnrollmentList from './components/templates/UserEnrollmentList';
-import Admin from './components/templates/Admin';
-import FAQ from './components/templates/Faq';
-import FormRouter from './components/organisms/FormRouter';
-import { AuthRequired, useAuth } from './components/organisms/AuthContext';
-import DataProviderList from './components/templates/DataProviderList';
 
 export const Routes = () => {
   const { user } = useAuth();
   const location = useLocation();
-  useLayoutEffect(() => window.scrollTo(0, 0), [location.pathname]);
+
+  useLayoutEffect(() => {
+    if (!location.state?.noScroll) {
+      window.scrollTo(0, 0);
+    }
+  }, [location.pathname, location.state?.noScroll]);
 
   return (
     <ReactRouterRoutes>

--- a/frontend/src/components/organisms/FormRouter.js
+++ b/frontend/src/components/organisms/FormRouter.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import useListItemNavigation from '../templates/hooks/use-list-item-navigation';
 import { DATA_PROVIDER_PARAMETERS } from '../../config/data-provider-parameters';
-import NotFound from './NotFound';
+import useListItemNavigation from '../templates/hooks/use-list-item-navigation';
 import { AuthRequired } from './AuthContext';
+import NotFound from './NotFound';
 
 const FormRouter = () => {
   const { targetApi } = useParams();
+
   const TargetApiComponent =
     DATA_PROVIDER_PARAMETERS[targetApi.replace(/-/g, '_')]?.component;
   const { goBackToList } = useListItemNavigation();

--- a/frontend/src/components/templates/Form/index.js
+++ b/frontend/src/components/templates/Form/index.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -6,22 +7,20 @@ import React, {
   useState,
 } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { isEmpty } from 'lodash';
-
-import { getUserEnrollment } from '../../../services/enrollments';
-import SubmissionPanel from './SubmissionPanel';
 import { DATA_PROVIDER_PARAMETERS } from '../../../config/data-provider-parameters';
 import { getStateFromUrlParams } from '../../../lib';
-import Nav from '../../organisms/Nav';
-import { Linkify } from '../../molecules/Linkify';
-import { enrollmentReducerFactory } from './enrollmentReducer';
-import './style.css';
+import { getUserEnrollment } from '../../../services/enrollments';
 import Alert from '../../atoms/Alert';
 import WarningEmoji from '../../atoms/icons/WarningEmoji';
+import { Linkify } from '../../molecules/Linkify';
 import HeadSection from '../../organisms/form-sections/HeadSection';
 import StepperSection from '../../organisms/form-sections/StepperSection';
-import useListItemNavigation from '../hooks/use-list-item-navigation';
+import Nav from '../../organisms/Nav';
 import NotFound from '../../organisms/NotFound';
+import useListItemNavigation from '../hooks/use-list-item-navigation';
+import { enrollmentReducerFactory } from './enrollmentReducer';
+import './style.css';
+import SubmissionPanel from './SubmissionPanel';
 
 export const FormContext = React.createContext();
 
@@ -116,7 +115,10 @@ export const Form = ({
 
   useEffect(() => {
     if (enrollment.id && !window.location.pathname.includes(enrollment.id)) {
-      navigate(`${enrollment.id}`, { replace: true });
+      navigate(`${enrollment.id}`, {
+        replace: true,
+        state: { noScroll: true },
+      });
     }
   }, [enrollment.id, navigate]);
 

--- a/frontend/src/components/templates/hooks/use-list-item-navigation.ts
+++ b/frontend/src/components/templates/hooks/use-list-item-navigation.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export const useListItemNavigation = () => {
   const location = useLocation();


### PR DESCRIPTION
Add a noScroll state in useEffect() callback -> template/form/index.js to prevent scrolling if forms are incomplete / get errors.