### PR TITLE
add class to helper tooltip

### DIFF
--- a/frontend/src/components/atoms/Helper/index.js
+++ b/frontend/src/components/atoms/Helper/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import HelpIcon from '../icons/help';
 import './style.css';
 
-const Helper = ({ title }) => {
+const Helper = ({ title = '' }) => {
   let helperClass = 'helper';
 
   if (title.length > 140) {

--- a/frontend/src/components/atoms/Helper/index.js
+++ b/frontend/src/components/atoms/Helper/index.js
@@ -1,13 +1,19 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import './style.css';
 import HelpIcon from '../icons/help';
+import './style.css';
 
-const Helper = ({ title }) => (
-  <span tooltip={title} className="helper">
-    <HelpIcon color={'var(--text-default-grey)'} />
-  </span>
-);
+const Helper = ({ title }) => {
+  let helperClass = 'helper';
+
+  if (title.length > 140) {
+    helperClass += ' helper-large';
+  }
+  return (
+    <span tooltip={title} className={helperClass}>
+      <HelpIcon color={'var(--text-default-grey)'} />
+    </span>
+  );
+};
 
 Helper.propTypes = {
   title: PropTypes.string,

--- a/frontend/src/components/atoms/Helper/style.css
+++ b/frontend/src/components/atoms/Helper/style.css
@@ -8,7 +8,7 @@
   vertical-align: middle;
 }
 
-.helper-large::after {
+.helper.helper-large::after {
   white-space: pre-line;
   min-width: 350px;
   text-align: left;

--- a/frontend/src/components/atoms/Helper/style.css
+++ b/frontend/src/components/atoms/Helper/style.css
@@ -8,6 +8,12 @@
   vertical-align: middle;
 }
 
+.helper-large::after {
+  white-space: pre-line;
+  min-width: 350px;
+  text-align: left;
+}
+
 /*CSS tooltip is heavily inspired from https://medium.freecodecamp.org/a-step-by-step-guide-to-making-pure-css-tooltips-3d5a3e237346*/
 [tooltip] {
   position: relative;

--- a/frontend/src/pages/DgfipPages/api-impot-particulier-common.js
+++ b/frontend/src/pages/DgfipPages/api-impot-particulier-common.js
@@ -1,5 +1,5 @@
-import { DonneesDescription as CommonDonneesDescription } from './common';
 import Link from '../../components/atoms/hyperTexts/Link';
+import { DonneesDescription as CommonDonneesDescription } from './common';
 
 export const DonneesDescription = () => (
   <>


### PR DESCRIPTION
when content text is wider than 140 characters
an helper-large class is add to adjust helper tooltip to min-width to 350px. 
