### PR TITLE
Add .env.test.local file + require dotenv.load in spec-helper

### DIFF
--- a/backend/app/.env.test.local
+++ b/backend/app/.env.test.local
@@ -1,0 +1,5 @@
+# Use for test Local environnement.
+
+PG_USER=datapass_test
+PG_PASSWORD=datapass_test
+PG_DATABASE=datapass_test

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -16,6 +16,14 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require 'dotenv'
+
+Dotenv.load(
+'.env.test.local',
+'.env.local',
+'.env'
+)
+
 require "webmock/rspec"
 
 RSpec.configure do |config|

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -16,12 +16,12 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'dotenv'
+require "dotenv"
 
 Dotenv.load(
-'.env.test.local',
-'.env.local',
-'.env'
+".env.test.local",
+".env.local",
+".env"
 )
 
 require "webmock/rspec"

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -19,9 +19,9 @@
 require "dotenv"
 
 Dotenv.load(
-".env.test.local",
-".env.local",
-".env"
+  ".env.test.local",
+  ".env.local",
+  ".env"
 )
 
 require "webmock/rspec"


### PR DESCRIPTION
force test to run with datapass-test db
if not test are running in datapass-dev db even with cmd line
` RAILS_ENV=test bundle exec rspec spec/<file>` forcing test env.