### PR TITLE
FixBug/sentry - Ignore 401 errors

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,11 +7,9 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 
 if (process.env.NODE_ENV === 'production') {
-  const serverErrorsRegex = new RegExp(`401 Unauthorized`, 'mi');
-
   Sentry.init({
     dsn: 'https://7ccf44097ef645f8835408b9d73e7781@sentry.data.gouv.fr/8',
-    ignoreErrors: [serverErrorsRegex],
+    ignoreErrors: ['Error: Request failed with status code 401'],
   });
 }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,14 +1,17 @@
+import '@gouvfr/dsfr/dist/dsfr/dsfr.css';
+import * as Sentry from '@sentry/react';
+import 'moment/locale/fr'; // set moment locale to french globally
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
-import '@gouvfr/dsfr/dist/dsfr/dsfr.css';
 import App from './App';
-import 'moment/locale/fr'; // set moment locale to french globally
-import * as Sentry from '@sentry/react';
 
 if (process.env.NODE_ENV === 'production') {
+  const serverErrorsRegex = new RegExp(`401 Unauthorized`, 'mi');
+
   Sentry.init({
     dsn: 'https://7ccf44097ef645f8835408b9d73e7781@sentry.data.gouv.fr/8',
+    ignoreErrors: [serverErrorsRegex],
   });
 }
 


### PR DESCRIPTION
See Sentry Docs https://docs.sentry.io/platforms/javascript/guides/react/configuration/filtering/
Find this solution from https://stackoverflow.com/questions/61651440/prevent-sentry-io-from-logging-server-error-codes

Regex flag mi standing for:
'm': multiline mode
'i': case insensitive
More Details about Regex Flag here : https://javascript.info/regexp-introduction