### PR TITLE
    feat: API Particulier implements webhooks to API Entreprise backend

### DIFF
--- a/backend/app/notifiers/api_particulier_notifier.rb
+++ b/backend/app/notifiers/api_particulier_notifier.rb
@@ -1,0 +1,21 @@
+class ApiParticulierNotifier < BaseNotifier
+  include WebhookNotifierMethods
+
+  def validate(comment:, current_user:)
+    super
+
+    deliver_event_webhook(__method__)
+  end
+
+  private
+
+  def webhook_payload_for(event)
+    WebhookSerializer.new(
+      @enrollment,
+      event.to_s,
+      {
+        external_token_id: @enrollment.linked_token_manager_id
+      }
+    ).serializable_hash
+  end
+end

--- a/backend/spec/acceptances/api_particulier_bridge_with_notifier_spec.rb
+++ b/backend/spec/acceptances/api_particulier_bridge_with_notifier_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API Particulier: bridge with notifier to API Entreprise", type: :request do
+  let(:enrollment) do
+    create(
+      :enrollment,
+      :api_particulier,
+      :complete,
+      status: :submitted
+    )
+  end
+  let(:token_id) { "over-9000" }
+  let(:user) { create(:user, roles: ["api_particulier:instructor"]) }
+  let(:stub_api_particulier_token_creation) do
+    stub_request(:post, "#{ENV["API_PARTICULIER_HOST"]}/api/applications").and_return(
+      headers: {
+        "Content-Type" => "application/json"
+      },
+      body: {
+        id: token_id
+      }.to_json,
+      status: 201
+    )
+  end
+
+  before do
+    login(user)
+
+    ENV["API_PARTICULIER_HOST"] = "http://particulier.api.gouv.local"
+    ENV["API_PARTICULIER_API_KEY"] = SecureRandom.uuid
+
+    stub_api_particulier_token_creation
+  end
+
+  after do
+    ENV["API_PARTICULIER_HOST"] = nil
+    ENV["API_PARTICULIER_API_KEY"] = nil
+  end
+
+  subject(:validate_enrollment) do
+    patch change_state_enrollment_path(id: enrollment.id, event: "validate", comment: "whatever")
+    response
+  end
+
+  it { is_expected.to have_http_status(:ok) }
+
+  it "calls bridge and update enrollnment with token id" do
+    expect {
+      validate_enrollment
+    }.to change { enrollment.reload.linked_token_manager_id }.to(token_id)
+  end
+
+  it "calls webhook with linked token manager id as extra data" do
+    expect(DeliverEnrollmentWebhookWorker).to receive(:perform_async).with(
+      enrollment.target_api,
+      hash_including(
+        data: {
+          pass: anything,
+          external_token_id: token_id
+        }
+      ),
+      enrollment.id
+    )
+
+    validate_enrollment
+  end
+end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include DeviseControllerLoginHelpers, type: :controller
+  config.include DeviseRequestLoginHelpers, type: :request
 
   config.include ApiInseePayloadHelpers
   FactoryBot::SyntaxRunner.send(:include, ApiInseePayloadHelpers)

--- a/backend/spec/support/devise_request_login_helpers.rb
+++ b/backend/spec/support/devise_request_login_helpers.rb
@@ -1,0 +1,14 @@
+module DeviseRequestLoginHelpers
+  include Warden::Test::Helpers
+
+  def login(resource_or_scope, resource = nil)
+    resource ||= resource_or_scope
+    scope = Devise::Mapping.find_scope!(resource_or_scope)
+    login_as(resource, scope: scope)
+  end
+
+  def logout(resource_or_scope)
+    scope = Devise::Mapping.find_scope!(resource_or_scope)
+    logout(scope)
+  end
+end


### PR DESCRIPTION
First step of a long migration from API Particulier infra to API Entreprise. This commit implements only a webhook for the validate event, which adds the token id to the payload in order to keeps old token and new token linked thanks to this id.

`API_PARTICULIER_WEBHOOK_URL` has to be set to https://entreprise.api.gouv.fr/api/datapass/api_particulier/webhook
and `API_PARTICULIER_VERIFY_TOKEN` has to be set to the value already set on `API_ENTREPRISE_VERIFY_TOKEN`