### PR TITLE
Add SETEC form

### DIFF
--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -409,5 +409,57 @@
         "extrait_court_inpi": false
       }
     }
+  },
+  "atexo": {
+    "label": "Éditeur Setec/Atexo - Dématérialisation des marchés publics",
+    "about": "https://entreprise.api.gouv.fr/use_cases/marches_publics/",
+    "team_members": {
+      "contact_metier": {
+        "email": "etienne.gaillat@setec.com",
+        "phone_number": "0524545533"
+      },
+      "responsable_technique": {
+        "email": "etienne.gaillat@setec.com",
+        "phone_number": "0524545533"
+      }
+    },
+    "state": {
+      "intitule": "Outil de dématérialisation des appels d'offres des marchés publics - Solution LOCAL TRUST MPE via SETEC",
+      "description": "Cette demande sous entend que vous avez fait appel à la société SETEC 702 005 901 00104 pour le traitement de vos marchés publics à travers la plateforme LOCAL TRUST MPE de Atexo.\r\nAfin de faciliter cette investigation du marché fournisseurs, ATEXO propose le module de Sourcing. Combiné au profil acheteur MPE, il permet aux entreprises de mettre en avant leurs informations.\r\nBasé sur l'open data et les renseignements des entreprises, ce module présente aux acheteurs des fiches fournisseurs complètes : établissements, éléments financiers, contrats publics, références significatives, expertises, contacts qualifiés, etc.",
+      "technical_team_type": "software_company",
+      "technical_team_value": "70200590100104",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, tel que défini par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
+      "data_retention_period": 36,
+      "data_recipients": "Acheteurs publics dans le cadre de leur activité de traitement des marchés publics",
+      "scopes": {
+        "entreprises": true,
+        "etablissements": true,
+        "extraits_rcs": true,
+        "associations": true,
+        "documents_association": true,
+        "actes_inpi": true,
+        "conventions_collectives": true,
+        "entreprises_artisanales": true,
+        "effectifs_acoss": true,
+        "eori_douanes": false,
+        "exercices": true,
+        "bilans_inpi": true,
+        "bilans_entreprise_bdf": false,
+        "liasse_fiscale": false,
+        "attestations_fiscales": true,
+        "attestations_sociales": true,
+        "attestations_agefiph": true,
+        "msa_cotisations": true,
+        "probtp": true,
+        "fntp_carte_pro": true,
+        "certificat_cnetp": true,
+        "certificat_agence_bio": true,
+        "certificat_rge_ademe": true,
+        "qualibat": true,
+        "certificat_opqibi": true,
+        "extrait_court_inpi": true
+      }
+    }
   }
 }

--- a/frontend/src/pages/ApiEntreprise/index.js
+++ b/frontend/src/pages/ApiEntreprise/index.js
@@ -219,6 +219,7 @@ const editorList = [
   { name: 'Klekoon', siret: '42140180300042' },
   { name: 'Mgdis', siret: '32816124500027' },
   { name: 'Provigis', siret: '43196025100061' },
+  { name: 'SETEC', siret: '70200590100104' },
   { name: 'Territoires Numériques BFC', siret: '13000493000025' },
 ];
 


### PR DESCRIPTION
SETEC n'est pas un éditeur à proprement parler, mais ils peuvent déployer des versions du logiciels d'Atexo pour le compte de leurs clients et le gère en leur nom.