### PR TITLE
Fix linter for rubocop dependabots 

### DIFF
--- a/backend/app/policies/enrollment/api_indemnisation_pole_emploi_policy.rb
+++ b/backend/app/policies/enrollment/api_indemnisation_pole_emploi_policy.rb
@@ -4,7 +4,7 @@ class Enrollment::ApiIndemnisationPoleEmploiPolicy < EnrollmentPolicy
 
     res.concat([
       scopes: [
-        :'api_fc-liste-paiementsv1'
+        :"api_fc-liste-paiementsv1"
       ]
     ])
 

--- a/backend/app/policies/enrollment/api_statut_demandeur_emploi_policy.rb
+++ b/backend/app/policies/enrollment/api_statut_demandeur_emploi_policy.rb
@@ -4,7 +4,7 @@ class Enrollment::ApiStatutDemandeurEmploiPolicy < EnrollmentPolicy
 
     res.concat([
       scopes: [
-        :'api_fc-statutaugmentev1'
+        :"api_fc-statutaugmentev1"
       ]
     ])
 


### PR DESCRIPTION
Add double quote instead of single quote
