### PR TITLE
Add team member type to export for enrollments

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -203,7 +203,7 @@ class Enrollment < ActiveRecord::Base
   end
 
   def team_members_json
-    team_members.to_json
+    team_members.to_json(methods: :type)
   end
 
   def link

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -203,7 +203,7 @@ class Enrollment < ActiveRecord::Base
   end
 
   def team_members_json
-    team_members.as_json
+    team_members.to_json
   end
 
   def link
@@ -246,7 +246,13 @@ class Enrollment < ActiveRecord::Base
       csv << attributes
 
       all.each do |enrollment|
-        csv << attributes.map { |attr| enrollment.send(attr) }
+        csv << attributes.map do |attr|
+          if attr == "scopes"
+            enrollment.scopes.to_json
+          else
+            enrollment.send(attr)
+          end
+        end
       end
     end
   end

--- a/backend/spec/controllers/enrollments/export_spec.rb
+++ b/backend/spec/controllers/enrollments/export_spec.rb
@@ -1,0 +1,49 @@
+require "csv"
+
+RSpec.describe EnrollmentsController, "#export", type: :controller do
+  describe "authorization" do
+    subject do
+      get :export
+    end
+
+    context "without user" do
+      it { is_expected.to have_http_status(:unauthorized) }
+    end
+
+    context "with user" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+  end
+
+  describe "payload" do
+    subject do
+      get :export
+      response.body
+    end
+
+    let(:user) { create(:instructor, target_api: "franceconnect") }
+    let!(:enrollment) { create(:enrollment, :franceconnect) }
+    let!(:foreign_enrollment) { create(:enrollment, :api_entreprise) }
+
+    before do
+      login(user)
+    end
+
+    it "is a valid csv, only on target apis" do
+      csv = CSV.parse(subject, headers: true)
+
+      expect(csv.count).to eq(1)
+
+      first_entry = csv.first
+
+      expect(first_entry["id"]).to eq(enrollment.id.to_s)
+      expect(first_entry["target_api"]).to eq("franceconnect")
+    end
+  end
+end

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -288,6 +288,12 @@ RSpec.describe Enrollment, type: :model do
           JSON.parse(subject)
         }.not_to raise_error
       end
+
+      it "renders type in team member payload" do
+        first_entry = JSON.parse(subject).first
+
+        expect(first_entry).to have_key("type")
+      end
     end
 
     describe "scopes entry" do

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -260,4 +260,22 @@ RSpec.describe Enrollment, type: :model do
       end
     end
   end
+
+  describe ".to_csv" do
+    subject { enrollments.to_csv }
+
+    let!(:enrollments_model) { create_list(:enrollment, 1, :api_entreprise) }
+    let(:enrollments) { Enrollment.all }
+
+    it "is a valid csv" do
+      csv = CSV.parse(subject, headers: true)
+
+      expect(csv.count).to eq(1)
+
+      first_entry = csv.first
+
+      expect(first_entry["id"]).to eq(enrollments.first.id.to_s)
+      expect(first_entry["target_api"]).to eq("api_entreprise")
+    end
+  end
 end

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -277,5 +277,29 @@ RSpec.describe Enrollment, type: :model do
       expect(first_entry["id"]).to eq(enrollments.first.id.to_s)
       expect(first_entry["target_api"]).to eq("api_entreprise")
     end
+
+    describe "team_members_json entry" do
+      subject do
+        CSV.parse(enrollments.to_csv, headers: true).first["team_members_json"]
+      end
+
+      it "is a valid json" do
+        expect {
+          JSON.parse(subject)
+        }.not_to raise_error
+      end
+    end
+
+    describe "scopes entry" do
+      subject do
+        CSV.parse(enrollments.to_csv, headers: true).first["scopes"]
+      end
+
+      it "is a valid json" do
+        expect {
+          JSON.parse(subject)
+        }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces:

* Some basic tests on export functionalities
* A bugfix on json attributes (which were ruby hash printed)
* type key for team_members_json