### PR TITLE
Ajoute formulaires Spécifique aux éditeurs et Portail GRU

### DIFF
--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -129,11 +129,46 @@
       }
     }
   },
+  "portail_gru": {
+    "label": "Portail gestion relation usager",
+    "about": "https://entreprise.api.gouv.fr/use_cases/portail_gru/",
+    "state": {
+      "intitule": "Portail de gestion relation usager/citoyen",
+      "description": "Cette demande d'habilitation spécifique au cas d'usage \"Portail gestion relation usager\" vous donne accès aux données ouvertes de l'API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra demander une habilitation supplémentaire par cas d’usage. Consultez no",
+      "scopes": {
+        "entreprises": true,
+        "etablissements": true,
+        "extraits_rcs": true,
+        "associations": true,
+        "documents_association": true,
+        "actes_inpi": true,
+        "conventions_collectives": true,
+        "entreprises_artisanales": true,
+        "effectifs_acoss": false,
+        "eori_douanes": true,
+        "exercices": false,
+        "bilans_inpi": false,
+        "bilans_entreprise_bdf": false,
+        "liasse_fiscale": false,
+        "attestations_fiscales": false,
+        "attestations_sociales": false,
+        "msa_cotisations": false,
+        "probtp": false,
+        "fntp_carte_pro": true,
+        "certificat_cnetp": false,
+        "certificat_agence_bio": true,
+        "certificat_rge_ademe": true,
+        "qualibat": true,
+        "certificat_opqibi": true,
+        "extrait_court_inpi": true
+      }
+    }
+  },
   "detection_fraude": {
     "label": "Détection de la fraude",
     "about": "https://entreprise.api.gouv.fr/use_cases/detection_fraude/",
     "state": {
-      "description": "Ce cas d'usage est EXCLUSIVEMENT réservé aux administrations dont la détection des fraudes fait parti de ses missions.",
+      "description": "Ce cas d'usage est EXCLUSIVEMENT réservé aux administrations dont la détection des fraudes fait partie de ses missions.",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -147,6 +182,46 @@
         "liasse_fiscale": true,
         "attestations_fiscales": true,
         "attestations_sociales": true
+      }
+    }
+  },
+  "default": {
+    "label": "Demande spécifiques aux éditeurs de logiciels",
+    "about": "https://entreprise.api.gouv.fr/use_cases/editeur/",
+    "state": {
+      "intitule": "Demande spécifiques aux éditeurs de logiciels",
+      "description": "Attention, cette demande concerne exclusivement les prestataires éditeurs de logiciels à destination d'acteurs publics.\r\n\r\nÉditeurs de logiciels, merci de répondre à toutes les questions suivantes :\r\n\r\n1-Quelles sont les différentes activités de votre organisation ? (description et site internet)\r\n\r\n2- Qui sont vos différents clients (privés et/ou publics) ?\r\n\r\n3- Qui seront les clients publics qui bénéficieront des données obtenues par l'API Entreprise ?\r\n\r\n4- À quoi sert le logiciel qui utilisera API Entreprise ? Décrivez-nous le produit et son rôle auprès de vos clients du secteur public.\r\n\r\n5- Quels sont les cas d'usage de vos clients publics ? Exemples : Marchés publics, Aides et subventions publiques, Portail de gestion relation usager, Fiabilisation de base de tiers, Autres ?",
+      "fondement_juridique_title": "",
+      "fondement_juridique_url": "",
+      "data_retention_period": "",
+      "data_recipients": "",
+      "scopes": {
+        "entreprises": false,
+        "etablissements": false,
+        "extraits_rcs": false,
+        "associations": false,
+        "documents_association": false,
+        "actes_inpi": false,
+        "conventions_collectives": false,
+        "entreprises_artisanales": false,
+        "effectifs_acoss": false,
+        "eori_douanes": false,
+        "exercices": false,
+        "bilans_inpi": false,
+        "bilans_entreprise_bdf": false,
+        "liasse_fiscale": false,
+        "attestations_fiscales": false,
+        "attestations_sociales": false,
+        "attestations_agefiph": false,
+        "msa_cotisations": false,
+        "probtp": false,
+        "fntp_carte_pro": false,
+        "certificat_cnetp": false,
+        "certificat_agence_bio": false,
+        "certificat_rge_ademe": false,
+        "qualibat": false,
+        "certificat_opqibi": false,
+        "extrait_court_inpi": false
       }
     }
   },

--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -117,8 +117,8 @@
     "label": "Pré-remplissage d’un formulaire",
     "about": "https://entreprise.api.gouv.fr/use_cases/preremplissage/",
     "state": {
-      "description": "Merci d’indiquer si le formulaire ou l’interface qui utilisera le pré-remplissage API Entreprise est :\r\n- en accès libre,\r\n- ou après authentification préalable, c’est à dire uniquement accessible à l’utilisateur concerné ou l’agent habilité à voir ces données.\r\n\r\nLes données protégées ne peuvent pas être exposées sur un formulaire librement accessible. Si le formulaire est en accès libre, seules les données ouvertes peuvent être utilisées pour le pré-remplissage. L’ensemble de ces éléments est synthétisé sur  https://entreprise.api.gouv.fr/use_cases/preremplissage/",
-      "fondement_juridique_title": "Article Premier de la LOI n° 2016-1321 du 7 octobre 2016 pour une République numérique",
+      "description": "Merci d’indiquer si le formulaire ou l’interface qui utilisera le pré-remplissage API Entreprise est :\r\n- en accès libre,\r\n- ou après authentification préalable, c’est-à-dire uniquement accessible à l’utilisateur concerné ou l’agent habilité à voir ces données.\r\n\r\nLes données protégées ne peuvent pas être exposées sur un formulaire librement accessible. Si le formulaire est en accès libre, seules les données ouvertes peuvent être utilisées pour le pré-remplissage. L’ensemble de ces éléments est synthétisé sur https://entreprise.api.gouv.fr/use_cases/preremplissage/",
+      "fondement_juridique_title": "Article Premier de la Loi n° 2016-1321 du 7 octobre 2016 pour une République numérique",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033202746/",
       "scopes": {
         "entreprises": false,

--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -135,6 +135,8 @@
     "state": {
       "intitule": "Portail de gestion relation usager/citoyen",
       "description": "Cette demande d’habilitation spécifique au cas d’usage \"Portail gestion relation usager\" vous donne uniquement accès aux données ouvertes de l’API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra faire une demande d’habilitation supplémentaire par cas d’usage.",
+      "fondement_juridique_title": "Article Premier de la LOI n° 2016-1321 du 7 octobre 2016 pour une République numérique",
+      "fondement_juridique_url": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033202746/",
       "scopes": {
         "entreprises": true,
         "etablissements": true,

--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -134,7 +134,7 @@
     "about": "https://entreprise.api.gouv.fr/use_cases/portail_gru/",
     "state": {
       "intitule": "Portail de gestion relation usager/citoyen",
-      "description": "Cette demande d'habilitation spécifique au cas d'usage \"Portail gestion relation usager\" vous donne accès aux données ouvertes de l'API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra demander une habilitation supplémentaire par cas d’usage. Consultez no",
+      "description": "Cette demande d'habilitation spécifique au cas d'usage \"Portail gestion relation usager\" vous donne uniquement accès aux données ouvertes de l'API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra faire une demande d'habilitation supplémentaire par cas d’usage.",
       "scopes": {
         "entreprises": true,
         "etablissements": true,

--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -121,11 +121,31 @@
       "fondement_juridique_title": "Article Premier de la LOI n° 2016-1321 du 7 octobre 2016 pour une République numérique",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033202746/",
       "scopes": {
-        "entreprises": true,
+        "entreprises": false,
         "etablissements": true,
         "extraits_rcs": true,
         "associations": true,
-        "entreprises_artisanales": true
+        "documents_association": true,
+        "actes_inpi": true,
+        "conventions_collectives": true,
+        "entreprises_artisanales": true,
+        "effectifs_acoss": false,
+        "eori_douanes": true,
+        "exercices": false,
+        "bilans_inpi": false,
+        "bilans_entreprise_bdf": false,
+        "liasse_fiscale": false,
+        "attestations_fiscales": false,
+        "attestations_sociales": false,
+        "msa_cotisations": false,
+        "probtp": false,
+        "fntp_carte_pro": true,
+        "certificat_cnetp": false,
+        "certificat_agence_bio": true,
+        "certificat_rge_ademe": true,
+        "qualibat": true,
+        "certificat_opqibi": true,
+        "extrait_court_inpi": true
       }
     }
   },
@@ -138,7 +158,7 @@
       "fondement_juridique_title": "Article Premier de la LOI n° 2016-1321 du 7 octobre 2016 pour une République numérique",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033202746/",
       "scopes": {
-        "entreprises": true,
+        "entreprises": false,
         "etablissements": true,
         "extraits_rcs": true,
         "associations": true,

--- a/frontend/src/pages/ApiEntreprise/demarches.json
+++ b/frontend/src/pages/ApiEntreprise/demarches.json
@@ -104,7 +104,7 @@
     }
   },
   "covid_19": {
-    "label": "Aide d'urgence régionale Covid-19 aux TPE",
+    "label": "Aide d’urgence régionale Covid-19 aux TPE",
     "about": "https://entreprise.api.gouv.fr/use_cases/covid_19/",
     "state": {
       "scopes": {
@@ -114,10 +114,10 @@
     }
   },
   "preremplissage": {
-    "label": "Pré-remplissage d'un formulaire",
+    "label": "Pré-remplissage d’un formulaire",
     "about": "https://entreprise.api.gouv.fr/use_cases/preremplissage/",
     "state": {
-      "description": "Merci d'indiquer si le formulaire ou l'interface qui utilisera le pré-remplissage API Entreprise est :\r\n- en accès libre,\r\n- ou après authentification préalable, c'est à dire uniquement accessible à l'utilisateur concerné ou l'agent habilité à voir ces données.\r\n\r\nLes données protégées ne peuvent pas être exposées sur un formulaire librement accessible. Si le formulaire est en accès libre, seules les données ouvertes peuvent être utilisées pour le pré-remplissage. L'ensemble de ces éléments est synthétisé sur  https://entreprise.api.gouv.fr/use_cases/preremplissage/",
+      "description": "Merci d’indiquer si le formulaire ou l’interface qui utilisera le pré-remplissage API Entreprise est :\r\n- en accès libre,\r\n- ou après authentification préalable, c’est à dire uniquement accessible à l’utilisateur concerné ou l’agent habilité à voir ces données.\r\n\r\nLes données protégées ne peuvent pas être exposées sur un formulaire librement accessible. Si le formulaire est en accès libre, seules les données ouvertes peuvent être utilisées pour le pré-remplissage. L’ensemble de ces éléments est synthétisé sur  https://entreprise.api.gouv.fr/use_cases/preremplissage/",
       "fondement_juridique_title": "Article Premier de la LOI n° 2016-1321 du 7 octobre 2016 pour une République numérique",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033202746/",
       "scopes": {
@@ -134,7 +134,7 @@
     "about": "https://entreprise.api.gouv.fr/use_cases/portail_gru/",
     "state": {
       "intitule": "Portail de gestion relation usager/citoyen",
-      "description": "Cette demande d'habilitation spécifique au cas d'usage \"Portail gestion relation usager\" vous donne uniquement accès aux données ouvertes de l'API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra faire une demande d'habilitation supplémentaire par cas d’usage.",
+      "description": "Cette demande d’habilitation spécifique au cas d’usage \"Portail gestion relation usager\" vous donne uniquement accès aux données ouvertes de l’API Entreprise. Si votre portail propose d’autres services, tels que la délivrance d’aides et subventions publiques ou encore un espace de candidature aux marchés publics et que vous souhaitez accéder à des données administratives protégées pour instruire les dossiers, il vous faudra faire une demande d’habilitation supplémentaire par cas d’usage.",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -168,7 +168,7 @@
     "label": "Détection de la fraude",
     "about": "https://entreprise.api.gouv.fr/use_cases/detection_fraude/",
     "state": {
-      "description": "Ce cas d'usage est EXCLUSIVEMENT réservé aux administrations dont la détection des fraudes fait partie de ses missions.",
+      "description": "Ce cas d’usage est EXCLUSIVEMENT réservé aux administrations dont la détection des fraudes fait partie de ses missions.",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -190,7 +190,7 @@
     "about": "https://entreprise.api.gouv.fr/use_cases/editeur/",
     "state": {
       "intitule": "Demande spécifiques aux éditeurs de logiciels",
-      "description": "Attention, cette demande concerne exclusivement les prestataires éditeurs de logiciels à destination d'acteurs publics.\r\n\r\nÉditeurs de logiciels, merci de répondre à toutes les questions suivantes :\r\n\r\n1-Quelles sont les différentes activités de votre organisation ? (description et site internet)\r\n\r\n2- Qui sont vos différents clients (privés et/ou publics) ?\r\n\r\n3- Qui seront les clients publics qui bénéficieront des données obtenues par l'API Entreprise ?\r\n\r\n4- À quoi sert le logiciel qui utilisera API Entreprise ? Décrivez-nous le produit et son rôle auprès de vos clients du secteur public.\r\n\r\n5- Quels sont les cas d'usage de vos clients publics ? Exemples : Marchés publics, Aides et subventions publiques, Portail de gestion relation usager, Fiabilisation de base de tiers, Autres ?",
+      "description": "Attention, cette demande concerne exclusivement les prestataires éditeurs de logiciels à destination d’acteurs publics.\r\n\r\nÉditeurs de logiciels, merci de répondre à toutes les questions suivantes :\r\n\r\n1- Quelles sont les différentes activités de votre organisation ? (description et site internet)\r\n\r\n2- Qui sont vos différents clients (privés et/ou publics) ?\r\n\r\n3- Qui seront les clients publics qui bénéficieront des données obtenues par l’API Entreprise ?\r\n\r\n4- À quoi sert le logiciel qui utilisera API Entreprise ? Décrivez-nous le produit et son rôle auprès de vos clients du secteur public.\r\n\r\n5- Quels sont les cas d’usage de vos clients publics ? Exemples : Marchés publics, Aides et subventions publiques, Portail de gestion relation usager, Fiabilisation de base de tiers, Autres ?",
       "fondement_juridique_title": "",
       "fondement_juridique_url": "",
       "data_retention_period": "",
@@ -239,14 +239,14 @@
       }
     },
     "state": {
-      "intitule": "Logiciel de contrôle de conformité des opérateurs économiques en vue de l'attribution ou du suivi des marchés - Solution e-Attestations",
-      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination de nos agents habilités en interne, leur permettant de récupérer les justificatifs nécessaires au dépôt et à l'instruction du dossier de candidature.\r\nL'accès à l'API Entreprise nous permettra d'accéder aux justificatifs sans avoir à les demander aux prestataires.\r\nCet outil s'appuie sur la solution de l’éditeur e-Attestations.",
+      "intitule": "Logiciel de contrôle de conformité des opérateurs économiques en vue de l’attribution ou du suivi des marchés - Solution e-Attestations",
+      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination de nos agents habilités en interne, leur permettant de récupérer les justificatifs nécessaires au dépôt et à l’instruction du dossier de candidature.\r\nL’accès à l’API Entreprise nous permettra d’accéder aux justificatifs sans avoir à les demander aux prestataires.\r\nCet outil s’appuie sur la solution de l’éditeur e-Attestations.",
       "technical_team_type": "software_company",
       "technical_team_value": "50382936800045",
-      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique, concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve :\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l’article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique, concernant l’accès des acheteurs aux documents justificatifs et moyens de preuve :\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
       "data_retention_period": 36,
-      "data_recipients": "Services marchés d'organismes publics et collectivités locales",
+      "data_recipients": "Services marchés d’organismes publics et collectivités locales",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -292,13 +292,13 @@
     },
     "state": {
       "intitule": "Outil de contrôle de conformité des titulaires de marchés - Solution Provigis",
-      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination de nos agents habilités en interne, leur permettant de collecter, contrôler et stocker les documents de conformité de leurs prestataires et sous-traitants.\r\nL'accès à l'API Entreprise nous permettra d'accéder aux justificatifs sans avoir à les demander aux prestataires.\r\n\r\nCet outil s'appuie sur la solution de l’éditeur Provigis.\r\n\r\nhttps://www.provigis.com/",
+      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination de nos agents habilités en interne, leur permettant de collecter, contrôler et stocker les documents de conformité de leurs prestataires et sous-traitants.\r\nL’accès à l’API Entreprise nous permettra d’accéder aux justificatifs sans avoir à les demander aux prestataires.\r\n\r\nCet outil s’appuie sur la solution de l’éditeur Provigis.\r\n\r\nhttps://www.provigis.com/",
       "technical_team_type": "software_company",
       "technical_team_value": "43196025100061",
-      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l’article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l’accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
       "data_retention_period": 36,
-      "data_recipients": "Services marchés d'organismes publics et collectivités locales",
+      "data_recipients": "Services marchés d’organismes publics et collectivités locales",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -343,14 +343,14 @@
       }
     },
     "state": {
-      "intitule": "Outil de contrôle de conformité des candidats et titulaires de marchés publics - Par l'éditeur Achat Solution",
-      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination des acheteurs adhérents, leur permettant de récupérer les justificatifs nécessaires au dépôt et à l'instruction du dossier de candidature ainsi qu'au contrôle périodique de la régularité fiscale et sociale des entreprises\r\nL'accès à l'API Entreprise nous permettra d'accéder aux justificatifs sans avoir à les demander aux prestataires.\r\nCet outil s'appuie sur la solution de l’éditeur Achat Solution.\r\n\r\nhttps://www.achat-solution.com/",
+      "intitule": "Outil de contrôle de conformité des candidats et titulaires de marchés publics - Par l’éditeur Achat Solution",
+      "description": "Dans le cadre des procédures de passation de marchés publics, nous mettons en place un outil, à destination des acheteurs adhérents, leur permettant de récupérer les justificatifs nécessaires au dépôt et à l’instruction du dossier de candidature ainsi qu’au contrôle périodique de la régularité fiscale et sociale des entreprises\r\nL’accès à l’API Entreprise nous permettra d’accéder aux justificatifs sans avoir à les demander aux prestataires.\r\nCet outil s’appuie sur la solution de l’éditeur Achat Solution.\r\n\r\nhttps://www.achat-solution.com/",
       "technical_team_type": "software_company",
       "technical_team_value": "81449011600013",
-      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l’article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, telle que définie par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l’accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
       "data_retention_period": 36,
-      "data_recipients": "Maître d'ouvrage, acheteurs publics dans le cadre de leurs contrôles de la régularité fiscale et sociale des entreprises",
+      "data_recipients": "Maître d’ouvrage, acheteurs publics dans le cadre de leurs contrôles de la régularité fiscale et sociale des entreprises",
       "scopes": {
         "entreprises": true,
         "etablissements": true,
@@ -395,11 +395,11 @@
       }
     },
     "state": {
-      "intitule": "Outil de dématérialisation des appels d'offres des marchés publics - Solution LOCAL TRUST MPE",
-      "description": "Afin de faciliter cette investigation du marché fournisseurs, ATEXO propose le module de Sourcing. Combiné au profil acheteur MPE, il permet aux entreprises de mettre en avant leurs informations.\r\nBasé sur l'open data et les renseignements des entreprises, ce module présente aux acheteurs des fiches fournisseurs complètes : établissements, éléments financiers, contrats publics, références significatives, expertises, contacts qualifiés, etc.",
+      "intitule": "Outil de dématérialisation des appels d’offres des marchés publics - Solution LOCAL TRUST MPE",
+      "description": "Afin de faciliter cette investigation du marché fournisseurs, ATEXO propose le module de Sourcing. Combiné au profil acheteur MPE, il permet aux entreprises de mettre en avant leurs informations.\r\nBasé sur l’open data et les renseignements des entreprises, ce module présente aux acheteurs des fiches fournisseurs complètes : établissements, éléments financiers, contrats publics, références significatives, expertises, contacts qualifiés, etc.",
       "technical_team_type": "software_company",
       "technical_team_value": "44090956200033",
-      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, tel que défini par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l’article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, tel que défini par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l’accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
       "data_retention_period": 36,
       "data_recipients": "Acheteurs publics dans le cadre de leur activité de traitement des marchés publics",
@@ -448,7 +448,7 @@
     },
     "state": {
       "intitule": "Solution de dématérialisation et de pilotage des aides - Solution Portail des aides",
-      "description": "Dans un objectif de dématérialisation des aides publiques, nous mettons en place un outil, à destination des usagers de notre organisme leur permettant de déposer des demandes d'aides/subventions, qui seront ensuite instruites par nos agents dans ce même outil.\r\nLa demande d’accès à API Entreprise est effectuée dans le but de faciliter le dépôt et l’instruction des demandes d’aides publiques pour les entreprises et associations du territoire, et de récupérer les justificatifs administratifs de ces organisations demandant des aides publiques, sans avoir à les demander aux demandeurs d'aides.\r\n\r\nLa plateforme, mise en place pour permettre le dépôt de ces aides publiques et l'instruction de ces demandes, s'appuie sur la solution « Portail des Aides » de l’éditeur MGDIS.",
+      "description": "Dans un objectif de dématérialisation des aides publiques, nous mettons en place un outil, à destination des usagers de notre organisme leur permettant de déposer des demandes d’aides/subventions, qui seront ensuite instruites par nos agents dans ce même outil.\r\nLa demande d’accès à API Entreprise est effectuée dans le but de faciliter le dépôt et l’instruction des demandes d’aides publiques pour les entreprises et associations du territoire, et de récupérer les justificatifs administratifs de ces organisations demandant des aides publiques, sans avoir à les demander aux demandeurs d’aides.\r\n\r\nLa plateforme, mise en place pour permettre le dépôt de ces aides publiques et l’instruction de ces demandes, s’appuie sur la solution « Portail des Aides » de l’éditeur MGDIS.",
       "technical_team_type": "software_company",
       "technical_team_value": "32816124500027",
       "fondement_juridique_title": "Décret n° 2019-31 du 18 janvier 2019 relatif aux échanges d’informations et de données entre administrations dans le cadre des démarches administratives et à l’expérimentation prévue par l’article 40 de la loi n° 2018-727 du 10 août 2018 pour un Etat au service d’une société de confiance",
@@ -499,11 +499,11 @@
       }
     },
     "state": {
-      "intitule": "Outil de dématérialisation des appels d'offres des marchés publics - Solution LOCAL TRUST MPE via SETEC",
-      "description": "Cette demande sous entend que vous avez fait appel à la société SETEC 702 005 901 00104 pour le traitement de vos marchés publics à travers la plateforme LOCAL TRUST MPE de Atexo.\r\nAfin de faciliter cette investigation du marché fournisseurs, ATEXO propose le module de Sourcing. Combiné au profil acheteur MPE, il permet aux entreprises de mettre en avant leurs informations.\r\nBasé sur l'open data et les renseignements des entreprises, ce module présente aux acheteurs des fiches fournisseurs complètes : établissements, éléments financiers, contrats publics, références significatives, expertises, contacts qualifiés, etc.",
+      "intitule": "Outil de dématérialisation des appels d’offres des marchés publics - Solution LOCAL TRUST MPE via SETEC",
+      "description": "Cette demande sous entend que vous avez fait appel à la société SETEC 702 005 901 00104 pour le traitement de vos marchés publics à travers la plateforme LOCAL TRUST MPE de Atexo.\r\nAfin de faciliter cette investigation du marché fournisseurs, ATEXO propose le module de Sourcing. Combiné au profil acheteur MPE, il permet aux entreprises de mettre en avant leurs informations.\r\nBasé sur l’open data et les renseignements des entreprises, ce module présente aux acheteurs des fiches fournisseurs complètes : établissements, éléments financiers, contrats publics, références significatives, expertises, contacts qualifiés, etc.",
       "technical_team_type": "software_company",
       "technical_team_value": "70200590100104",
-      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l'article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, tel que défini par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l'accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
+      "fondement_juridique_title": "Service numérique de conformité pour les administrations publiques dans le cadre du décret N°2011-1601 et de l’article D8222 du code du travail, offre de services d’intermédiation aux organismes publics, tel que défini par l’article 17, alinéa IV, du décret du 24 septembre 2014 et le décret lié à la commande publique n° 2016-360.\r\nhttps://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/\r\n\r\nArticle R2143-13 du code de la commande publique. Concernant l’accès des acheteurs aux documents justificatifs et moyens de preuve.\r\nhttps://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037730589",
       "fondement_juridique_url": "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000018520702/2011-12-31/",
       "data_retention_period": 36,
       "data_recipients": "Acheteurs publics dans le cadre de leur activité de traitement des marchés publics",

--- a/frontend/src/pages/ApiEntreprise/index.js
+++ b/frontend/src/pages/ApiEntreprise/index.js
@@ -30,7 +30,7 @@ const DonneesDescription = () => (
       </li>
       <li>
         des{' '}
-        <Link inline newTab href="https://entreprise.api.gouv.fr/cas_usage/">
+        <Link inline newTab href="https://entreprise.api.gouv.fr/cas_usages">
           cas d’usage
         </Link>{' '}
         proposés par API Entreprise. Nous y décrivons les données utiles par


### PR DESCRIPTION
Cette PR ajoute : 
- le formulaire pré-rempli pour le cas d'utilisation Portail GRU
- le formulaire pré-rempli pour le cas d'utilisation spécifique des éditeurs
- la bonne url vers la page cas d'usage car actuellement ça renvoit une 404

A vérifier avant de merger : 
J'ai ajouté pas mal de texte dans les descriptions des formulaires pré-remplis, j'ai normalement mis des retours à la ligne mais je ne peux pas voir moi-même le résultat.