### PR TITLE
Hot Fix : Removed Redis.exists_returns_integer it's now always enabled.

### DIFF
--- a/backend/config/initializers/redis.rb
+++ b/backend/config/initializers/redis.rb
@@ -1,1 +1,1 @@
-Redis.exists_returns_integer = false
+# Be sure to restart your server when you modify this file.


### PR DESCRIPTION
 remove backend/config/initializers/redis.rb since new version of Redi…s Removed Redis.exists_returns_integer, it's now always enabled.