### PR TITLE
HotFix Archive PR

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -64,7 +64,7 @@ class Enrollment < ActiveRecord::Base
     end
 
     event :archive do
-      transition from: %i[draft changes_requested submitted refused revoked validated], to: :archived
+      transition from: all, to: :archived
     end
 
     event :validate do

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -34,8 +34,6 @@ class Enrollment < ActiveRecord::Base
   accepts_nested_attributes_for :team_members
   has_many :users, through: :team_members
 
-  default_scope -> { where.not(status: "archived") }
-
   state_machine :status, initial: :draft, namespace: "status" do
     state :draft
     state :submitted

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -64,7 +64,7 @@ class Enrollment < ActiveRecord::Base
     end
 
     event :archive do
-      transition from: all, to: :archived
+      transition from: all - [:archived], to: :archived
     end
 
     event :validate do


### PR DESCRIPTION
Refacto `enrollment_policy`
- an administrator could in future have access to enrollment with an archived status. 
- change `default_scope -> { where.not(status: "archived") }` as it prevents us to have access to enrollments with an archive status in console.
=> this is now handle with the `class Scope`

Refacto `state event transition`

