### PR TITLE
Feat/change requested enrollments 6 months old send remail

### DIFF
--- a/backend/app/mailers/enrollment_reminder_mailer.rb
+++ b/backend/app/mailers/enrollment_reminder_mailer.rb
@@ -17,6 +17,19 @@ class EnrollmentReminderMailer < ActionMailer::Base
     )
   end
 
+  def reminder_changes_requested_enrollment_email
+    @target_api_label = data_provider_config["label"]
+    @enrollment = Enrollment.find(params[:enrollment_id])
+
+    mail(
+      to: @enrollment.demandeurs.pluck(:email),
+      from: "notifications@api.gouv.fr",
+      subject: "Votre demande d’habilitation à #{@target_api_label} vous attend.",
+      template_path: "enrollment_mailer/demandeur",
+      template_name: "reminder_changes_requested_enrollment"
+    )
+  end
+
   private
 
   def data_provider_config

--- a/backend/app/services/extract_changes_requested_enrollments_to_archive.rb
+++ b/backend/app/services/extract_changes_requested_enrollments_to_archive.rb
@@ -3,7 +3,7 @@
 class ExtractChangesRequestedEnrollmentsToArchive
   attr_reader :enrollment
 
-  OLDEST_CHANGES_REQUESTED_ENROLLMENTS = Time.now.beginning_of_day - 9.months
+  OLDEST_CHANGES_REQUESTED_ENROLLMENTS = Time.new(2022, 5, 1)
 
   def call
     last_request_changes_or_update_events = last_request_changes_or_update_events_for_enrollments

--- a/backend/app/services/extract_changes_requested_enrollments_to_archive.rb
+++ b/backend/app/services/extract_changes_requested_enrollments_to_archive.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ExtractChangesRequestedEnrollmentsToArchive
+  attr_reader :enrollment
+
+  OLDEST_CHANGES_REQUESTED_ENROLLMENTS = Time.now.beginning_of_day - 9.months
+
+  def call
+    last_request_changes_or_update_events = last_request_changes_or_update_events_for_enrollments
+    enrollment_ids = last_request_changes_or_update_events.pluck(:enrollment_id)
+    Enrollment.find(enrollment_ids)
+  end
+
+  def changes_requested_enrollments
+    Enrollment.where(status: "changes_requested")
+      .where({updated_at: OLDEST_CHANGES_REQUESTED_ENROLLMENTS...Time.now.ago(6.months).beginning_of_day})
+      .includes(:events)
+      .where({events: {name: %w[request_changes update reminder]}})
+      .order(:id, "events.created_at")
+  end
+
+  def last_request_changes_or_update_events_for_enrollments
+    enrollments = changes_requested_enrollments
+    events = enrollments.map { |enrollment| enrollment.events.last }.to_a
+    events.reject { |event| event.name == "reminder" }
+  end
+end

--- a/backend/app/views/enrollment_mailer/demandeur/reminder_changes_requested_enrollment.text.erb
+++ b/backend/app/views/enrollment_mailer/demandeur/reminder_changes_requested_enrollment.text.erb
@@ -3,18 +3,18 @@ Bonjour,
 
 
 Nous vous contactons aujourd’hui car vous avez sur DataPass au moins une demande d’habilitation juridique en statut « Modifications Demandées » depuis au moins 6 mois.
-Dans un souci d’archivage des demandes n'étant plus d’actualités, nous supprimerons bientôt toutes les demandes d’habilitation concernées.
+Dans un souci d’archivage des demandes n’étant plus d’actualité, nous archiverons bientôt toutes les demandes d’habilitation concernées : vous n’y aurez plus accès.
 
-Vous ne souhaitez pas que cette habilitation soit supprimée ? Deux options s’offrent à vous :
+Vous ne souhaitez pas que cette habilitation soit archivée ? Deux options s’offrent à vous :
 
-- Aller sur https://datapass.api.gouv.fr/, puis cliquer sur « Consulter » sur la/les habilitation(s) concernée(s) et procéder aux modifications demandées. Si vous cliquez sur « Enregistrer les modifications », votre habilitation ne sera pas supprimée. Si vous cliquez sur « Soumettre la demande d’habilitation », non seulement elle ne sera pas oubliée, mais l'équipe instructrice pourra étudier à nouveau votre demande.
+- Aller sur https://datapass.api.gouv.fr/, puis cliquer sur « Consulter » sur la/les habilitation(s) concernée(s) et procéder aux modifications demandées. Si vous cliquez sur « Enregistrer les modifications », votre habilitation ne sera pas archivée. Si vous cliquez sur « Soumettre la demande d’habilitation », non seulement elle ne sera pas oubliée, mais l’équipe instructrice pourra étudier à nouveau votre demande.
 
 - Nous contacter à datapass@api.gouv.fr pour que nous conservions la/les habilitation(s) active(s).
 
-En l’absence d’action ou de réponse de votre part, la/les habilitation(s) concernée(s) seront supprimées dans 15 jours, et vous ne pourrez alors plus y accéder.
+En l’absence d’action ou de réponse de votre part, la/les habilitation(s) concernée(s) seront archivées dans 15 jours, et vous ne pourrez alors plus y accéder.
 
 Nous restons disponibles pour toute question sur le sujet.
 
 Bien cordialement,
 
-L'équipe DataPass
+L’équipe DataPass

--- a/backend/app/views/enrollment_mailer/demandeur/reminder_changes_requested_enrollment.text.erb
+++ b/backend/app/views/enrollment_mailer/demandeur/reminder_changes_requested_enrollment.text.erb
@@ -1,0 +1,20 @@
+Bonjour,
+
+
+
+Nous vous contactons aujourd’hui car vous avez sur DataPass au moins une demande d’habilitation juridique en statut « Modifications Demandées » depuis au moins 6 mois.
+Dans un souci d’archivage des demandes n'étant plus d’actualités, nous supprimerons bientôt toutes les demandes d’habilitation concernées.
+
+Vous ne souhaitez pas que cette habilitation soit supprimée ? Deux options s’offrent à vous :
+
+- Aller sur https://datapass.api.gouv.fr/, puis cliquer sur « Consulter » sur la/les habilitation(s) concernée(s) et procéder aux modifications demandées. Si vous cliquez sur « Enregistrer les modifications », votre habilitation ne sera pas supprimée. Si vous cliquez sur « Soumettre la demande d’habilitation », non seulement elle ne sera pas oubliée, mais l'équipe instructrice pourra étudier à nouveau votre demande.
+
+- Nous contacter à datapass@api.gouv.fr pour que nous conservions la/les habilitation(s) active(s).
+
+En l’absence d’action ou de réponse de votre part, la/les habilitation(s) concernée(s) seront supprimées dans 15 jours, et vous ne pourrez alors plus y accéder.
+
+Nous restons disponibles pour toute question sur le sujet.
+
+Bien cordialement,
+
+L'équipe DataPass

--- a/backend/app/workers/schedule_reminder_email_for_change_requested_enrollments_worker.rb
+++ b/backend/app/workers/schedule_reminder_email_for_change_requested_enrollments_worker.rb
@@ -2,8 +2,8 @@
 
 require "sidekiq-scheduler"
 
-class ScheduleReminderEmailForChangeRequestedEnrollmentsWorker
-  include Sidekiq::Worker
+class ScheduleReminderEmailForChangeRequestedEnrollmentsWorker < ApplicationWorker
+  sidekiq_options queue: "reminders"
 
   def perform
     ExtractChangesRequestedEnrollmentsToArchive.new.call.each do |changes_requested_enrollment|

--- a/backend/app/workers/schedule_reminder_email_for_change_requested_enrollments_worker.rb
+++ b/backend/app/workers/schedule_reminder_email_for_change_requested_enrollments_worker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "sidekiq-scheduler"
+
+class ScheduleReminderEmailForChangeRequestedEnrollmentsWorker
+  include Sidekiq::Worker
+
+  def perform
+    ExtractChangesRequestedEnrollmentsToArchive.new.call.each do |changes_requested_enrollment|
+      send_reminder_email(changes_requested_enrollment)
+      create_reminder_event(changes_requested_enrollment)
+    end
+  end
+
+  def send_reminder_email(enrollment)
+    EnrollmentReminderMailer.with(
+      target_api: enrollment.target_api,
+      enrollment_id: enrollment.id
+    ).reminder_changes_requested_enrollment_email.deliver_later
+  end
+
+  def create_reminder_event(enrollment)
+    enrollment.events.create!(name: "reminder")
+  end
+end

--- a/backend/app/workers/schedule_reminder_email_for_draft_enrollments_worker.rb
+++ b/backend/app/workers/schedule_reminder_email_for_draft_enrollments_worker.rb
@@ -2,8 +2,8 @@
 
 require "sidekiq-scheduler"
 
-class ScheduleReminderEmailForDraftEnrollmentsWorker
-  include Sidekiq::Worker
+class ScheduleReminderEmailForDraftEnrollmentsWorker < ApplicationWorker
+  sidekiq_options queue: "reminders"
 
   def perform
     ExtractDraftEnrollmentsToRemind.new.call.each do |draft_enrollment|

--- a/backend/config/sidekiq.yml
+++ b/backend/config/sidekiq.yml
@@ -13,3 +13,8 @@
     cron: '0 6 * * *'  # Runs every day at 06:00 am / cron: minute hour day(month) month day(week)
     class: ScheduleReminderEmailForDraftEnrollmentsWorker
     queue: reminders
+  schedule_reminder_email_for_change_requested_enrollments_worker:
+    cron: '0 7 * * *'  # Runs every day at 07:00 am / cron: minute hour day(month) month day(week)
+    class: ScheduleReminderEmailForChangeRequestedEnrollmentsWorker
+    queue: reminders
+

--- a/backend/spec/services/extract_changes_requested_enrollments_to_archive_spec.rb
+++ b/backend/spec/services/extract_changes_requested_enrollments_to_archive_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+RSpec.describe ExtractChangesRequestedEnrollmentsToArchive, type: :service do
+  subject { described_class.new }
+
+  describe "enrollments not included in #changes_requested_enrollments call" do
+    before do
+      Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
+    end
+
+    before do
+      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: 7.months.ago, updated_at: 6.months.ago)
+      create(:event, :request_changes, enrollment: enrollment, created_at: (6.months.ago + 5.days), updated_at: (6.months.ago + 5.days))
+      create(:event, :update, enrollment: enrollment, created_at: 6.months.ago, updated_at: 6.months.ago)
+
+      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: 2.months.ago, updated_at: 1.month.ago)
+      create(:event, :request_changes, enrollment: enrollment, created_at: 1.month.ago, updated_at: 1.month.ago)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "does not renders changes_requested enrollments less than 6 months old" do
+      result = subject.changes_requested_enrollments
+      enrollment = result.map { |enrollment| enrollment.target_api }
+
+      expect(enrollment).to eq([])
+    end
+  end
+
+  describe "#changes_requested enrollments" do
+    context "when it includes only enrollment with a changes_requested status and request_changes, update or reminder events" do
+      before do
+        Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
+      end
+
+      before do
+        enrollment = create(:enrollment, :api_entreprise, :validated, created_at: (9.months.ago + 5.days), updated_at: (8.months.ago + 28.days))
+        create(:event, :create, enrollment: enrollment, created_at: (9.months.ago + 5.days), updated_at: (9.months.ago + 5.days))
+        create(:event, :update, enrollment: enrollment, created_at: 9.months.ago, updated_at: 9.months.ago)
+        create(:event, :submit, enrollment: enrollment, created_at: 9.months.ago, updated_at: 9.months.ago)
+        create(:event, :validate, enrollment: enrollment, created_at: (8.months.ago + 28.days), updated_at: (8.months.ago + 28.days))
+
+        enrollment = create(:enrollment, :franceconnect, :changes_requested, created_at: (8.months.ago + 15.days), updated_at: 8.months.ago)
+        create(:event, :create, enrollment: enrollment, created_at: (8.months.ago + 15.days), updated_at: (8.months.ago + 15.days))
+        create(:event, :update, enrollment: enrollment, created_at: (8.months.ago + 5.days), updated_at: (8.month.ago + 5.days))
+        create(:event, :submit, enrollment: enrollment, created_at: (8.months.ago + 5.days), updated_at: (8.month.ago + 5.days))
+        create(:event, :request_changes, enrollment: enrollment, created_at: (8.months.ago + 5.days), updated_at: (8.month.ago + 5.days))
+        create(:event, :reminder, enrollment: enrollment, created_at: 8.months.ago, updated_at: 8.months.ago)
+
+        enrollment = create(:enrollment, :api_impot_particulier_fc_sandbox, :changes_requested, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 10.days))
+        create(:event, :create, enrollment: enrollment, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 25.days))
+        create(:event, :notify, enrollment: enrollment, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 25.days))
+        create(:event, :update, enrollment: enrollment, created_at: (6.months.ago - 10.days), updated_at: (6.months.ago - 10.days))
+        create(:event, :submit, enrollment: enrollment, created_at: (6.months.ago - 10.days), updated_at: (6.months.ago - 10.days))
+        create(:event, :request_changes, enrollment: enrollment, created_at: (6.months.ago - 10.days), updated_at: (6.months.ago - 10.days))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "renders changes_requested enrollments between 9 months and 6 month ago" do
+        result = subject.changes_requested_enrollments
+
+        expect(result.count).to eq(2)
+      end
+    end
+  end
+
+  context "checking enrollment's events" do
+    before do
+      Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
+    end
+
+    before do
+      enrollment = create(:enrollment, :franceconnect, :changes_requested, created_at: (8.months.ago - 25.days), updated_at: 8.months.ago)
+      create(:event, :create, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
+      create(:event, :submit, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
+      create(:event, :request_changes, enrollment: enrollment, created_at: (8.months.ago - 20.days), updated_at: (8.months.ago - 20.days))
+      create(:event, :reminder, enrollment: enrollment, created_at: 8.months.ago, updated_at: 8.months.ago)
+
+      enrollment = create(:enrollment, :api_impot_particulier_fc_sandbox, :changes_requested, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :create, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :submit, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :request_changes, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :update, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+
+      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 24.days))
+      create(:event, :create, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
+      create(:event, :submit, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
+      create(:event, :notify, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
+      create(:event, :request_changes, enrollment: enrollment, created_at: (6.months.ago - 24.days), updated_at: (6.months.ago - 24.days))
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "includes draft enrollment with no notify events" do
+      result = subject.changes_requested_enrollments
+      events = result.map { |enrollment| enrollment.events.map(&:name) }.flatten
+
+      expect(events).to include("request_changes", "update", "reminder")
+      expect(events).not_to include("notify", "create")
+    end
+
+    it "orders enrollment by id and last events created" do
+      result = subject.changes_requested_enrollments
+      event_names = result.collect { |e| e.events.map(&:name) }
+      event_ids = result.collect { |e| e.events.ids }
+
+      expect(event_names[0].last).to eq("reminder")
+      expect(event_ids[0].last).to eq(result[0].events.last.id)
+    end
+
+    context "#last_request_changes_or_update_events_for_enrollments" do
+      it "renders request_changes or update as last events" do
+        result = subject.last_request_changes_or_update_events_for_enrollments
+        events = result.map { |event| event.name }.flatten
+
+        expect(result.count).to eq(2)
+        expect(events).to include("request_changes")
+      end
+    end
+  end
+end

--- a/backend/spec/workers/schedule_reminder_email_for_change_requested_enrollments_worker_spec.rb
+++ b/backend/spec/workers/schedule_reminder_email_for_change_requested_enrollments_worker_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScheduleReminderEmailForChangeRequestedEnrollmentsWorker, type: :worker do
+  subject { described_class.new }
+
+  describe "#perform" do
+    before do
+      Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
+    end
+
+    before do
+      enrollment = create(:enrollment, :franceconnect, :changes_requested, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :create, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :submit, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :request_changes, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :update, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    describe "email sends to demandeurs when enrollment is in changes_requested status for more than 6 months" do
+      include ActiveJob::TestHelper
+
+      after do
+        clear_enqueued_jobs
+        clear_performed_jobs
+      end
+
+      context "when enrollment is in changes_requested status for more than 6 months" do
+        it "sends email to demandeurs" do
+          subject.perform
+
+          enqueued_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs
+          reminder_email = enqueued_jobs.find { |job| job["arguments"][1] == "reminder_changes_requested_enrollment_email" }
+
+          expect(ActiveJob::Base.queue_adapter.enqueued_jobs.size).to eq 1
+          expect(reminder_email).to be_truthy
+        end
+      end
+    end
+
+    describe "email sent" do
+      let(:reminder_changes_requested_sample) do
+        File.open(Rails.root.join("app/views/enrollment_mailer/demandeur/reminder_changes_requested_enrollment.text.erb")) { |f| f.readline }.chomp
+      end
+
+      before do
+        ActiveJob::Base.queue_adapter = :inline
+      end
+
+      after do
+        ActiveJob::Base.queue_adapter = :test
+      end
+
+      it "delivers a return receipt email to current user" do
+        expect {
+          subject.perform
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+        last_email = ActionMailer::Base.deliveries.last
+
+        expect(last_email.body).to include(reminder_changes_requested_sample)
+        expect(last_email.subject).to eq("Votre demande d’habilitation à FranceConnect vous attend.")
+      end
+    end
+
+    describe "#create_reminder_event" do
+      it "create an event reminder if email is sent to demandeur" do
+        reminder_enrollments = subject.perform
+        enrollment = reminder_enrollments.first
+        last_enrollment_event = enrollment.events.last
+
+        expect(enrollment.events.count).to eq(5)
+        expect(last_enrollment_event.name).to eq("reminder")
+      end
+    end
+  end
+
+  describe "#perform when there is no changes_requested enrollments" do
+    before do
+      Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
+    end
+
+    before do
+      enrollment = create(:enrollment, :franceconnect, :changes_requested, created_at: 7.months.ago, updated_at: 6.months.ago)
+      create(:event, :create, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :request_changes, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:event, :reminder, enrollment: enrollment, created_at: 6.months.ago, updated_at: 6.months.ago)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "does not raise" do
+      expect { subject.perform }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
**Process to test the worker cron job**

- in a console window, open the rails console 
```ruby
bundle exec rails c
```

- Clear all Sidekiq Queues
```ruby
Sidekiq::Queue.all.each(&:clear)
Sidekiq::RetrySet.new.clear
Sidekiq::ScheduledSet.new.clear
Sidekiq::DeadSet.new.clear
```

- Launch Sidekiq : 
```shell
bundle exec sidekiq --environment development -C config/sidekiq.yml
``` 
![Capture d’écran 2023-02-03 à 14 26 37](https://user-images.githubusercontent.com/43042737/216614780-8f35eebe-66ab-4216-bf10-eb86830704cd.png)

The following lines about the cron schedule exepression with worker and sidekiq queue should be displayed : 
```shell
2023-02-03T13:25:18.780Z pid=24953 tid=7rl INFO: Scheduling schedule_reminder_email_for_draft_enrollments_worker {"cron"=>"0 6 * * *", "class"=>"ScheduleReminderEmailForDraftEnrollmentsWorker", "queue"=>"reminders"}
2023-02-03T13:25:18.782Z pid=24953 tid=7rl INFO: Scheduling schedule_reminder_email_for_change_requested_enrollments_worker {"cron"=>"0 7 * * *", "class"=>"ScheduleReminderEmailForChangeRequestedEnrollmentsWorker", "queue"=>"reminders"}
```

- Launch the project in localhost (frontend and backend)
- Launch a rails console in a new console window
and call the Worker 
```ruby
bundle exec rails c
$ load "schedule_reminder_email_for_draft_enrollments_worker.rb"
# => true
$  ScheduleReminderEmailForDraftEnrollmentsWorker.new.perform
```

