### PR TITLE
cant not archive a validated enrollment

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -64,7 +64,7 @@ class Enrollment < ActiveRecord::Base
     end
 
     event :archive do
-      transition from: all - [:archived], to: :archived
+      transition from: all - [:archived, :validated], to: :archived
     end
 
     event :validate do

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -77,8 +77,8 @@ class EnrollmentPolicy < ApplicationPolicy
       user.belongs_to_organization?(record) &&
       user.is_demandeur?(record)
 
-    instructor_right = !record.status_validated? && user.is_instructor?(record.target_api)
-    administrator_right = !record.status_validated? && user.is_administrator?
+    instructor_right = user.is_instructor?(record.target_api)
+    administrator_right = user.is_administrator?
 
     record.can_archive_status? && (demandeur_rights || instructor_right || administrator_right)
   end

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -77,8 +77,8 @@ class EnrollmentPolicy < ApplicationPolicy
       user.belongs_to_organization?(record) &&
       user.is_demandeur?(record)
 
-    instructor_right = user.is_instructor?(record.target_api)
-    administrator_right = user.is_administrator?
+    instructor_right = !record.status_validated? && user.is_instructor?(record.target_api)
+    administrator_right = !record.status_validated? && user.is_administrator?
 
     record.can_archive_status? && (demandeur_rights || instructor_right || administrator_right)
   end

--- a/backend/spec/controllers/enrollments/change_state_spec.rb
+++ b/backend/spec/controllers/enrollments/change_state_spec.rb
@@ -826,6 +826,7 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
 
     describe "with user being an instructor" do
       let(:user) { create(:user, roles: ["franceconnect:instructor"]) }
+
       context "for a validated enrollment" do
         let(:enrollment_status) { :validated }
 
@@ -833,7 +834,17 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
           login(user)
         end
 
-        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to have_http_status(:forbidden) }
+      end
+
+      context "for an archived enrollment" do
+        let(:enrollment_status) { :archived }
+
+        before do
+          login(user)
+        end
+
+        it { is_expected.to have_http_status(:forbidden) }
       end
 
       context "for a draft enrollment" do
@@ -845,17 +856,51 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
       end
+
+      context "for a revoked enrollment" do
+        let(:enrollment_status) { :revoked }
+
+        before do
+          login(user)
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+      end
     end
 
-    context "with user not being an instructor" do
+    describe "with user being not beeing an instructor or admin" do
+      context "for a validated enrollment" do
+        let(:user) { create(:user, roles: ["user"]) }
+        let(:enrollment_status) { :validated }
+
+        before do
+          login(user)
+        end
+
+        it { is_expected.to have_http_status(:forbidden) }
+      end
+    end
+
+    context "for an enrollment with status draft" do
       let(:user) { create(:user, roles: ["user"]) }
-      let(:enrollment_status) { :validated }
+      let(:enrollment_status) { :draft }
 
       before do
         login(user)
       end
 
-      it { is_expected.to have_http_status(:forbidden) }
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context "for an enrollment with change_requested status" do
+      let(:user) { create(:user, roles: ["user"]) }
+      let(:enrollment_status) { :changes_requested }
+
+      before do
+        login(user)
+      end
+
+      it { is_expected.to have_http_status(:ok) }
     end
   end
 end


### PR DESCRIPTION
instructor and administrator can no longer archive a validated enrollment. enrollment has to be revoked before.


https://user-images.githubusercontent.com/43042737/229558005-e373ddca-02bb-4dc5-aa4c-8c501192d892.mov

