### PR TITLE
Fix some UI bugs on the new Instructor Homepage 🤕

### DIFF
--- a/frontend/src/components/molecules/QuickViewList/EnrollmentQuickView.tsx
+++ b/frontend/src/components/molecules/QuickViewList/EnrollmentQuickView.tsx
@@ -40,14 +40,20 @@ const EnrollmentQuickView: React.FC<Props> = ({ enrollment }) => {
       onClick={markAsRead}
     >
       <div className="quick-view-informations quick-view-informations--small">
-        <div className="quick-view-header">
-          {isUnreadSubmittedEnrollment && (
+        {isUnreadSubmittedEnrollment && (
+          <div className="quick-view-header">
             <Badge type={BadgeType.new} icon={true} small={true}>
               Nouveau
             </Badge>
-          )}
+          </div>
+        )}
+        <div
+          className={`quick-view-title ${
+            isUnreadSubmittedEnrollment ? 'quick-view-title--new' : ''
+          }`}
+        >
+          {enrollment.intitule}
         </div>
-        <div className="quick-view-title">{enrollment.intitule}</div>
         <div className="quick-view-date">
           soumis le {moment(getSubmitDate()).format('DD/MM/YYYY')}
         </div>

--- a/frontend/src/components/molecules/QuickViewList/styles.css
+++ b/frontend/src/components/molecules/QuickViewList/styles.css
@@ -44,8 +44,11 @@
 }
 
 .quick-view-title {
-  font-weight: bold;
   display: flex;
+}
+
+.quick-view-title--new {
+  font-weight: bold;
 }
 
 .quick-view-icon {

--- a/frontend/src/components/templates/InstructorHome.tsx
+++ b/frontend/src/components/templates/InstructorHome.tsx
@@ -104,7 +104,17 @@ const InstructorHome: React.FC = () => {
               <IconTitle title="Habilitations à instruire" icon="target" />
               <QuickViewList list={enrollments} type="enrollments" />
               <div className="action-footer">
-                <Button href="/habilitations" secondary>
+                <Button
+                  href={`/habilitations${`?${qs.stringify({
+                    filtered: JSON.stringify([
+                      {
+                        id: 'target_api',
+                        value: targetApis,
+                      },
+                    ]),
+                  })}`}`}
+                  secondary
+                >
                   Toutes les habilitations à instruire
                 </Button>
               </div>
@@ -116,6 +126,10 @@ const InstructorHome: React.FC = () => {
                 <Button
                   href={`/habilitations${`?${qs.stringify({
                     filtered: JSON.stringify([
+                      {
+                        id: 'target_api',
+                        value: targetApis,
+                      },
                       {
                         id: 'only_with_unprocessed_messages',
                         value: true,


### PR DESCRIPTION
Bugs are listed below :

- si j'ai sélectionné des API dans la page Accueil et que je clique sur "Toutes mes habilitations à instruire" ou "Tous mes messages non lus", mon choix est visible dans la page Tableau
- Pas de marge supplémentaire au-dessus du titre de l'habilitation si je n'ai pas le badge Nouveau
- Si l'habilitation n'a pas le badge Nouveau, le titre n'est pas en gras