### PR TITLE
Fix Archive CRON Damages 💥

### DIFF
--- a/backend/db/migrate/20230510091641_fix_archive_cron_damages.rb
+++ b/backend/db/migrate/20230510091641_fix_archive_cron_damages.rb
@@ -1,0 +1,27 @@
+class FixArchiveCronDamages < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      cron_archived_enrollments = Enrollment.joins(:events).where({
+        events: {user_id: nil, name: "archive", created_at: ..DateTime.new(2023, 3, 20)}
+      }).distinct
+
+      cron_archived_enrollments.each do |enrollment|
+        # Reatribute previous status name
+        enrollment_events_names = enrollment.events.pluck(:name)
+        enrollment.status = if enrollment_events_names.include?("request_changes")
+          "changes_requested"
+        else
+          "draft"
+        end
+
+        # Delete wrong archive event
+        enrollment.events.find_by(name: "archive")&.destroy
+
+        enrollment.save!
+      end
+
+      dir.down do
+      end
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_19_095535) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_091641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Petite explication du correctif à l'attention d'@Isalafont :

**_Contexte du problème :_**

- Le CRON (user 0) a archivé des habilitations par erreur.
- Activation déployée le 7 Mars à 9:43.
- Désactivation déployée le 15 Mars à 18:11.

_**Résolution du problème :**_

Raphaël et moi avons convenu que supprimer simplement les archivages effectués par le CRON malveillant avant la date du 20 Mars (la désactivation a eu lieu le 15 au soir, mais par sécurité nous avons préféré laisser une marge) et restaurer les statuts des habilitations concernées à leur état précédent, pourrait facilement réinitialiser la situation.

En effet, en restaurant ces habilitations à leur état d'origine, elles seront à nouveau sujettes au CRON d'archivage qui, cette fois, est correct.

Le seul petit inconvénient de cette méthode est que les habilitations concernées conserveront leurs événements de rappel (`reminder`). Ces événements resteront consultables dans l'historique des habilitations, par exemple.