### PR TITLE
Sanitize `phone_number` for Team Members 📞

### DIFF
--- a/backend/app/models/team_member.rb
+++ b/backend/app/models/team_member.rb
@@ -12,6 +12,7 @@ class TeamMember < ActiveRecord::Base
     end
   end
 
+  before_validation :clean_phone_number
   belongs_to :enrollment
   belongs_to :user, optional: true
   before_save :set_user, if: :will_save_change_to_email?
@@ -24,6 +25,10 @@ class TeamMember < ActiveRecord::Base
 
   def has_linked_user
     true
+  end
+
+  def clean_phone_number
+    self.phone_number = phone_number&.gsub(/\D/, "") unless phone_number.nil?
   end
 
   protected

--- a/backend/db/migrate/20230523081445_clean_phone_numbers_in_team_members.rb
+++ b/backend/db/migrate/20230523081445_clean_phone_numbers_in_team_members.rb
@@ -1,0 +1,12 @@
+class CleanPhoneNumbersInTeamMembers < ActiveRecord::Migration[7.0]
+  def up
+    TeamMember.find_each do |team_member|
+      cleaned_phone_number = team_member.phone_number.gsub(/\D/, "") unless team_member.phone_number.nil?
+      team_member.update_column(:phone_number, cleaned_phone_number)
+    end
+  end
+
+  def down
+    # The down method is intentionally left blank because the changes made in the up method can't be reversed.
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_091641) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_081445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -235,6 +235,38 @@ RSpec.describe Enrollment, type: :model do
           expect(subject["team_members"]["2"]["email"]).to eq(["hoho@santa.claus"])
         end
       end
+
+      context "with modification of a non-sanitized phone_number in team_members" do
+        before do
+          tm = JSON.parse(enrollment.team_members.to_json)
+          enrollment.update!(
+            team_members_attributes: [
+              {
+                id: tm[0]["id"],
+                type: "demandeur",
+                email: tm[0]["email"],
+                phone_number: tm[0]["phone_number"],
+                job: tm[0]["job"],
+                given_name: tm[0]["given_name"],
+                family_name: tm[0]["family_name"]
+              },
+              {
+                id: tm[1]["id"],
+                type: "responsable_technique",
+                email: tm[1]["email"],
+                phone_number: "0158453286‬",
+                job: tm[1]["job"],
+                given_name: tm[1]["given_name"],
+                family_name: tm[1]["family_name"]
+              }
+            ]
+          )
+        end
+
+        it "returns a diff for modified phone_number with sanitized value in associated model" do
+          expect(subject["team_members"]["1"]["phone_number"]).to eq(["0636656565", "0158453286"])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**Description du bug** : @SchweisguthN a signalé un problème étrange. Les numéros de téléphone du Délégué à la protection des données (DPD) sont refusés sur le formulaire Captchetat. Le bug a été constaté sur l'habilitation spécifique à l'URL https://datapass.api.gouv.fr/api-captchetat/52062#head. Nicolas a également essayé en environnement de staging et n'a pas pu soumettre une demande, rencontrant la même erreur.

**Actions effectuées** : Après avoir examiné le problème, j'ai constaté que l'utilisateur avait saisi des caractères invisibles dans le numéro de téléphone. Pour résoudre ce problème, un nettoyage a été ajouté à la validation du numéro de téléphone, supprimant tous les caractères non numériques. De plus, une migration a été créée pour nettoyer les numéros de téléphone existants dans la base de données.