### PR TITLE
[API Particulier] Retire le scope mesri_identifiant

### DIFF
--- a/backend/config/data_providers.yml
+++ b/backend/config/data_providers.yml
@@ -112,9 +112,6 @@ api_particulier:
     - value: men_echelon_bourse
       label: Échelon de la bourse
       helper: Indique l’échelon de l’élève boursier
-    - value: mesri_identifiant
-      label: Numéro INE
-      helper: Permet d'accéder à l'identifiant national de l’étudiant (INE).
     - value: mesri_identite
       label: Statut étudiant inscrit et identité
       helper: Indique si le particulier est étudiant "inscrit", et le cas échéant transmet nom, prénom et date de naissance de l'étudiant. Pour accéder aux étudiants "admis", cocher la case "Périmètre étudiants admis".
@@ -183,7 +180,6 @@ api_particulier:
         - mesri_inscription_etudiant
         - mesri_inscription_autre
         - mesri_etablissements
-        - mesri_identifiant
     cnous:
       label: API Statut étudiant boursier
       scopes:
@@ -271,7 +267,6 @@ api_particulier:
           pole_emploi_contact: false
           pole_emploi_adresse: false
           pole_emploi_inscription: false
-          mesri_identifiant: false
           mesri_identite: false
           mesri_inscription_etudiant: false
           mesri_inscription_autre: false
@@ -594,7 +589,6 @@ api_particulier:
           pole_emploi_contact: true
           pole_emploi_adresse: true
           pole_emploi_inscription: true
-          mesri_identifiant: true
           mesri_identite: true
           cnous_statut_bourse: true
           cnous_identite: true


### PR DESCRIPTION
Cette API retire le scope `mesri_identifiant` qui renvoyait l'INE.
Il a été décidé de supprimer ce périmètre car la donnée renvoyée ne provient pas du FD mais est celle présente en paramètre d'appel dans le cas de l'utilisation de la modalité d'appel INE.
Ce champ n'a donc pas d'intérêt pour l'usager.