### PR TITLE
Fix augment permitted attributes in policies

### DIFF
--- a/backend/app/models/enrollment/api_r2p_unique.rb
+++ b/backend/app/models/enrollment/api_r2p_unique.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Enrollment::ApiR2pUnique < Enrollment::UniqueEnrollment
+  include DgfipValidationMethods
 end

--- a/backend/app/policies/enrollment/api_ficoba_sandbox_policy.rb
+++ b/backend/app/policies/enrollment/api_ficoba_sandbox_policy.rb
@@ -4,11 +4,7 @@ class Enrollment::ApiFicobaSandboxPolicy < Enrollment::SandboxPolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: ficoba_permitted_scopes,
-      additional_content: super_additional_content(res) + ficoba_permitted_acces
-    ])
-
-    res
+    res[:scopes] = ficoba_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *ficoba_permitted_acces)
   end
 end

--- a/backend/app/policies/enrollment/api_ficoba_unique_policy.rb
+++ b/backend/app/policies/enrollment/api_ficoba_unique_policy.rb
@@ -4,11 +4,8 @@ class Enrollment::ApiFicobaUniquePolicy < Enrollment::UniquePolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: ficoba_permitted_scopes,
-      additional_content: super_additional_content(res) + ficoba_permitted_acces
-    ])
-
+    res[:scopes] = ficoba_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *ficoba_permitted_acces)
     res
   end
 end

--- a/backend/app/policies/enrollment/api_impot_particulier_sandbox_policy.rb
+++ b/backend/app/policies/enrollment/api_impot_particulier_sandbox_policy.rb
@@ -4,12 +4,8 @@ class Enrollment::ApiImpotParticulierSandboxPolicy < Enrollment::SandboxPolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: impot_particulier_permitted_scopes,
-      additional_content:
-        super_additional_content(res) + impot_particulier_permitted_acces
-    ])
-
+    res[:scopes] = impot_particulier_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *impot_particulier_permitted_acces)
     res
   end
 end

--- a/backend/app/policies/enrollment/api_impot_particulier_unique_policy.rb
+++ b/backend/app/policies/enrollment/api_impot_particulier_unique_policy.rb
@@ -4,12 +4,8 @@ class Enrollment::ApiImpotParticulierUniquePolicy < Enrollment::UniquePolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: impot_particulier_permitted_scopes,
-      additional_content:
-        super_additional_content(res) + impot_particulier_permitted_acces
-    ])
-
+    res[:scopes] = impot_particulier_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *impot_particulier_permitted_acces)
     res
   end
 end

--- a/backend/app/policies/enrollment/api_r2p_sandbox_policy.rb
+++ b/backend/app/policies/enrollment/api_r2p_sandbox_policy.rb
@@ -2,12 +2,6 @@ class Enrollment::ApiR2pSandboxPolicy < Enrollment::SandboxPolicy
   include DgfipPolicyMethods
 
   def permitted_attributes
-    res = super
-
-    res.concat([
-      additional_content: super_additional_content(res) + r2p_permitted_acces
-    ])
-
-    res
+    augment_permitted_attributes(super, :additional_content, *r2p_permitted_acces)
   end
 end

--- a/backend/app/policies/enrollment/api_r2p_unique_policy.rb
+++ b/backend/app/policies/enrollment/api_r2p_unique_policy.rb
@@ -2,12 +2,6 @@ class Enrollment::ApiR2pUniquePolicy < Enrollment::UniquePolicy
   include DgfipPolicyMethods
 
   def permitted_attributes
-    res = super
-
-    res.concat([
-      additional_content: super_additional_content(res) + r2p_permitted_acces
-    ])
-
-    res
+    augment_permitted_attributes(super, :additional_content, *r2p_permitted_acces)
   end
 end

--- a/backend/app/policies/enrollment/api_sfip_sandbox_policy.rb
+++ b/backend/app/policies/enrollment/api_sfip_sandbox_policy.rb
@@ -6,12 +6,8 @@ class Enrollment::ApiSfipSandboxPolicy < Enrollment::SandboxPolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: impot_particulier_permitted_scopes,
-      additional_content:
-        super_additional_content(res) + impot_particulier_permitted_acces
-    ])
-
+    res[:scopes] = impot_particulier_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *impot_particulier_permitted_acces)
     res
   end
 end

--- a/backend/app/policies/enrollment/api_sfip_unique_policy.rb
+++ b/backend/app/policies/enrollment/api_sfip_unique_policy.rb
@@ -6,12 +6,8 @@ class Enrollment::ApiSfipUniquePolicy < Enrollment::UniquePolicy
   def permitted_attributes
     res = super
 
-    res.concat([
-      scopes: impot_particulier_permitted_scopes,
-      additional_content:
-        super_additional_content(res) + impot_particulier_permitted_acces
-    ])
-
+    res[:scopes] = impot_particulier_permitted_scopes
+    augment_permitted_attributes(res, :additional_content, *impot_particulier_permitted_acces)
     res
   end
 end

--- a/backend/app/policies/enrollment/unique_policy.rb
+++ b/backend/app/policies/enrollment/unique_policy.rb
@@ -4,18 +4,6 @@ class Enrollment::UniquePolicy < Enrollment::SandboxPolicy
   end
 
   def permitted_attributes
-    res = super
-
-    res.concat([
-      additional_content: super_additional_content(res) + [
-        :autorite_homologation_nom,
-        :autorite_homologation_fonction,
-        :date_homologation,
-        :date_fin_homologation,
-        :volumetrie_appels_par_minute
-      ]
-    ])
-
-    res
+    augment_permitted_attributes(super, :additional_content, :autorite_homologation_nom, :autorite_homologation_fonction, :date_homologation, :date_fin_homologation, :volumetrie_appels_par_minute)
   end
 end

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -99,11 +99,16 @@ class EnrollmentPolicy < ApplicationPolicy
     user.is_instructor?(record.target_api)
   end
 
-  def super_additional_content(res)
-    super_additional_content_attribute = res.find do |att|
-      att.instance_of?(Hash) && att.key?(:additional_content)
+  def augment_permitted_attributes(attributes, key, *new_values)
+    attribute_hash = attributes.find { |attribute| attribute.is_a?(Hash) && attribute.key?(key) }
+
+    if attribute_hash
+      attribute_hash[key] += new_values
+    else
+      attributes << {key => new_values}
     end
-    super_additional_content_attribute[:additional_content]
+
+    attributes
   end
 
   def permitted_attributes

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -101,13 +101,7 @@ class EnrollmentPolicy < ApplicationPolicy
 
   def augment_permitted_attributes(attributes, key, *new_values)
     attribute_hash = attributes.find { |attribute| attribute.is_a?(Hash) && attribute.key?(key) }
-
-    if attribute_hash
-      attribute_hash[key] += new_values
-    else
-      attributes << {key => new_values}
-    end
-
+    attribute_hash[key] += new_values
     attributes
   end
 

--- a/backend/spec/factories/enrollments.rb
+++ b/backend/spec/factories/enrollments.rb
@@ -395,5 +395,24 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :api_r2p_unique do
+      initialize_with do
+        Enrollment::ApiR2pUnique.new(attributes)
+      end
+
+      team_members do
+        [
+          {
+            type: "responsable_metier",
+            email: "user-metier@clamart.fr",
+            phone_number: "0626656565",
+            job: "Directeur",
+            given_name: "Jean",
+            family_name: "Dupont"
+          }
+        ]
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problème

Dans les classes Enrollment::UniquePolicy et Enrollment::ApiR2pUniquePolicy, lors de l'ajout de nouvelles valeurs à la clé :additional_content, nous utilisions concat pour ajouter une nouvelle entrée au tableau d'attributs, créant ainsi une nouvelle clé à chaque fois plutôt que de mettre à jour la clé existante.

### Solution apportée

Pour résoudre ce problème, j'ai introduit une méthode utilitaire appelée augment_permitted_attributes. Cette méthode prend en entrée un tableau d'attributs, une clé et de nouvelles valeurs à ajouter. Elle recherche d'abord si le tableau d'attributs contient déjà une clé correspondante. Si c'est le cas, elle met à jour la valeur de cette clé en ajoutant les nouvelles valeurs. Sinon, elle ajoute une nouvelle entrée au tableau avec la clé et les nouvelles valeurs.