### PR TITLE
Introduce ENV FRONTAL for ops

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -61,8 +61,6 @@ module DataPass
     config.action_mailer.raise_delivery_errors = false
     config.action_mailer.default charset: "utf-8"
 
-    config.action_mailer.perform_deliveries = true
-
     # remove scheme from url
     uri = URI(ENV.fetch("BACK_HOST"))
     config.action_mailer.default_url_options = {host: uri.hostname + uri.path}
@@ -75,11 +73,6 @@ module DataPass
       authentication: :plain,
       enable_starttls_auto: true
     }
-
-    if ENV.fetch("DO_NOT_SEND_MAIL", "False") == "True"
-      config.action_mailer.perform_deliveries = false
-      config.action_mailer.delivery_method = :test
-    end
 
     if ENV.fetch("FORCE_COOKIES_SAME_SITE_PROTECTION", "False") != "True" &&
         ENV.fetch("ALLOWED_ORIGINS", "").include?("localhost")

--- a/backend/config/environments/test.rb
+++ b/backend/config/environments/test.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
+  config.action_mailer.perform_deliveries = false
   config.action_mailer.delivery_method = :test
   config.active_job.queue_adapter = :test
 

--- a/backend/config/initializers/frontal.rb
+++ b/backend/config/initializers/frontal.rb
@@ -1,0 +1,1 @@
+ENV["FRONTAL"] = "true"

--- a/backend/config/initializers/frontal_mailer.rb
+++ b/backend/config/initializers/frontal_mailer.rb
@@ -1,0 +1,1 @@
+Rails.application.config.action_mailer.perform_deliveries = (ENV["FRONTAL"] == "true")


### PR DESCRIPTION
Will be override in deployment, in order to not deliver daily emails defined in scheduler (like API Parteprise site)

Related https://github.com/etalab/admin_api_entreprise/commit/90ca749024fcd590bd44b32780c45734b3a74108