### PR TITLE
Update index.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,7 +13,7 @@
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/favicons/favicon.svg">
-    <link rel="shrotcut icon" type="image/x-icon" href="%PUBLIC_URL%/favicons/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/favicons/favicon.ico">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="192x192" href="%PUBLIC_URL%/favicons/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="%PUBLIC_URL%/favicons/android-chrome-512x512.png">


### PR DESCRIPTION
[d'après la documentation](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/rel) : 

> Note : Le type de lien shortcut est souvent vu avant icon, mais ce type de lien est non conforme, ignoré et les auteurs web ne doivent plus l'utiliser.

Le type de lien shrotcut en revanche, est rarement vu avant icon.