### PR TITLE
Enhance config information about MCP client id

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -14,5 +14,5 @@ INSEE_HOST=https://insee.fr
 INSEE_CONSUMER_KEY=INSEE_CONSUMER_KEY
 INSEE_CONSUMER_SECRET=INSEE_CONSUMER_SECRET
 FORCE_COOKIES_SAME_SITE_PROTECTION=False
-DATAPASS_OAUTH_CLIENT_ID=https://github.com/betagouv/moncomptepro/blob/master/scripts/fixtures.sql#L237
+DATAPASS_OAUTH_CLIENT_ID=https://github.com/betagouv/moncomptepro/blob/03262ee424da5fda4c96efddf77698ba78e89751/scripts/fixtures.sql#L242
 API_PARTICULIER_ACCOUNT_URL=https://staging.particulier.api.gouv.fr/compte

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,14 @@ psql -f db/setup.local.sql
 rails db:schema:load
 ```
 
+## Configuration
+
+Modifier le fichier `.env.development` pour y ajouter le client ID de
+MonComptePro de test (clé `DATAPASS_OAUTH_CLIENT_ID`), le client id se trouve
+dans le fichier [fixture de
+MonComptePro](https://github.com/betagouv/moncomptepro/blob/master/scripts/fixtures.sql)
+(lien dans le fichier `.env` aussi)
+
 ## Tests
 
 ```sh


### PR DESCRIPTION
Because of the "secret" nature of client_id it can't be push to repo because of GitGuardian alerts and betagouv policy.

This commit enhance documentation and keep track of this behaviour thanks to this commit through git blame.