### PR TITLE
API Particulier validate mailer: fix wrong url

### DIFF
--- a/backend/app/views/enrollment_mailer/api_particulier/validate.text.erb
+++ b/backend/app/views/enrollment_mailer/api_particulier/validate.text.erb
@@ -1,7 +1,7 @@
 Bonjour <%= "#{@user.given_name} #{@user.family_name}" %>,
 
 Votre habilitation n°<%= @enrollment.id %> a bien été validée ✅ par notre service juridique !
-Votre jeton d’accès a été créé 🔑 et est disponible dans votre portail à l’adresse suivante <%= @url %>
+Votre jeton d’accès a été créé 🔑 et est disponible dans votre portail à l’adresse suivante https://particulier.api.gouv.fr/compte
 
 Votre contact technique et vous-même pouvez vous y connecter pour le récupérer.
 


### PR DESCRIPTION
@url in this context redirects to datapass, not the API manager

Related https://support.etalab.gouv.fr/#ticket/zoom/65522