### PR TITLE
Redirect to demarches simplifiées on API TP form routing

### DIFF
--- a/frontend/src/components/atoms/ExternalRedirect/index.tsx
+++ b/frontend/src/components/atoms/ExternalRedirect/index.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+function ExternalRedirect({ url }: { url: string }) {
+  useEffect(() => {
+    window.location.href = url;
+  }, [url]);
+
+  return null;
+}
+
+export default ExternalRedirect;

--- a/frontend/src/components/organisms/FormRouter.tsx
+++ b/frontend/src/components/organisms/FormRouter.tsx
@@ -5,14 +5,22 @@ import Loader from '../atoms/Loader';
 import Enrollment from '../templates/Enrollment';
 import { useFullDataProvider } from '../templates/hooks/use-full-data-provider';
 import NotFound from './NotFound';
+import ExternalRedirect from '../atoms/ExternalRedirect';
+import { TargetAPI } from '../../config/data-provider-configurations';
 
 const FormRouter = () => {
-  const { targetApi: targetApiFromUrl } = useParams();
+  const { targetApi: targetApiFromUrl, enrollmentId } = useParams();
   const targetApi = (targetApiFromUrl as string).replace(/-/g, '_');
 
   const { Component, configuration, notFound } = useFullDataProvider({
     targetApi: targetApi as string,
   });
+
+  if (targetApi === TargetAPI.api_tiers_de_prestation && !enrollmentId) {
+    return (
+      <ExternalRedirect url="https://www.demarches-simplifiees.fr/commencer/api-tiers-de-prestations" />
+    );
+  }
 
   if (notFound) {
     return <NotFound />;


### PR DESCRIPTION
L'objectif est de rediriger l'utilisateur vers DS lorsqu'il accède au formulaire de l'API TP.

Le code vérifie d'abord si l'API mentionnée dans l'URL correspond à l'API TP. Ensuite, il cherche la présence d'un `enrollmentId` dans cette même URL. Si un `enrollmentId` est détecté, cela signifie que l'utilisateur se trouve sur le détail d'une habilitation API TP déjà établie. Dans une telle situation, il est essentiel de permettre à l'utilisateur de maintenir son accès.