### PR TITLE
FIX MonComptePro configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Vous pouvez également utiliser les comptes de tests suivants :
 Ce dépôt de code vous permet d’instancier un environnement de développement local pour DataPass.
 Pour ce faire merci de prendre connaissance de la suite du document (en anglais).
 
+## Ajouter une nouvelle source de données
+
+Se référer à [Ajout d'un nouveau fournisseur](./backend/docs/new_enrollment.md)
+
 ## Development
 
 ### Requirements

--- a/backend/app/models/concerns/enrollment_validators/validate_at_least_one_scope_presence.rb
+++ b/backend/app/models/concerns/enrollment_validators/validate_at_least_one_scope_presence.rb
@@ -1,0 +1,21 @@
+module EnrollmentValidators::ValidateAtLeastOneScopePresence
+  extend ActiveSupport::Concern
+
+  protected
+
+  def submit_validation
+    super
+
+    validate_at_least_one_scope_is_present
+  end
+
+  def validate_at_least_one_scope_is_present
+    if scopes.empty?
+      errors.add(:scopes, :invalid, message: no_scopes_present_error_message)
+    end
+  end
+
+  def no_scopes_present_error_message
+    "Vous devez cocher au moins un périmètre de données avant de continuer"
+  end
+end

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -523,13 +523,6 @@ class Enrollment < ActiveRecord::Base
     end
   end
 
-  def scopes_validation
-    if scopes.empty?
-      errors.add(:scopes, :invalid,
-        message: "Vous devez cocher au moins un périmètre de données avant de continuer")
-    end
-  end
-
   def previous_enrollment_id_validation
     unless previous_enrollment_id.present?
       errors.add(:previous_enrollment_id, :invalid,

--- a/backend/app/models/enrollment/agent_connect_fi.rb
+++ b/backend/app/models/enrollment/agent_connect_fi.rb
@@ -1,10 +1,11 @@
 class Enrollment::AgentConnectFi < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     unless additional_content&.fetch("authorize_access_to_service_providers", false)&.present?
       errors.add(:additional_content, :invalid, message: "Vous devez autoriser les FS à utiliser les données transmises par AgentConnect")

--- a/backend/app/models/enrollment/agent_connect_fs.rb
+++ b/backend/app/models/enrollment/agent_connect_fs.rb
@@ -1,10 +1,11 @@
 class Enrollment::AgentConnectFs < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_captchetat.rb
+++ b/backend/app/models/enrollment/api_captchetat.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiCaptchetat < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_droits_cnam.rb
+++ b/backend/app/models/enrollment/api_droits_cnam.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiDroitsCnam < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/api_entreprise.rb
+++ b/backend/app/models/enrollment/api_entreprise.rb
@@ -1,11 +1,12 @@
 class Enrollment::ApiEntreprise < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
     technical_team_validation
-    scopes_validation
     team_members_validation("responsable_technique", "contact technique")
     team_members_validation("contact_metier", "contact métier")
   end

--- a/backend/app/models/enrollment/api_histovec.rb
+++ b/backend/app/models/enrollment/api_histovec.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiHistovec < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_indemnisation_pole_emploi.rb
+++ b/backend/app/models/enrollment/api_indemnisation_pole_emploi.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiIndemnisationPoleEmploi < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/api_indemnites_journalieres_cnam.rb
+++ b/backend/app/models/enrollment/api_indemnites_journalieres_cnam.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiIndemnitesJournalieresCnam < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     previous_enrollment_id_validation
     responsable_technique_validation
   end

--- a/backend/app/models/enrollment/api_ingres.rb
+++ b/backend/app/models/enrollment/api_ingres.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiIngres < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_particulier.rb
+++ b/backend/app/models/enrollment/api_particulier.rb
@@ -1,11 +1,12 @@
 class Enrollment::ApiParticulier < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
     technical_team_validation
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_prestations_sociales.rb
+++ b/backend/app/models/enrollment/api_prestations_sociales.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiPrestationsSociales < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_prestations_sociales_fc.rb
+++ b/backend/app/models/enrollment/api_prestations_sociales_fc.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiPrestationsSocialesFc < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/api_pro_sante_connect.rb
+++ b/backend/app/models/enrollment/api_pro_sante_connect.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiProSanteConnect < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_scolarite.rb
+++ b/backend/app/models/enrollment/api_scolarite.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiScolarite < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_service_national.rb
+++ b/backend/app/models/enrollment/api_service_national.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiServiceNational < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/api_statut_demandeur_emploi.rb
+++ b/backend/app/models/enrollment/api_statut_demandeur_emploi.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiStatutDemandeurEmploi < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/api_statut_etudiant.rb
+++ b/backend/app/models/enrollment/api_statut_etudiant.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiStatutEtudiant < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/api_statut_etudiant_boursier.rb
+++ b/backend/app/models/enrollment/api_statut_etudiant_boursier.rb
@@ -1,10 +1,11 @@
 class Enrollment::ApiStatutEtudiantBoursier < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     previous_enrollment_id_validation
   end

--- a/backend/app/models/enrollment/franceconnect.rb
+++ b/backend/app/models/enrollment/franceconnect.rb
@@ -1,10 +1,11 @@
 class Enrollment::Franceconnect < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
-    scopes_validation
     responsable_technique_validation
     unless additional_content&.fetch("has_alternative_authentication_methods", false)&.present?
       errors.add(:additional_content, :invalid, message: "Vous devez attester que votre service propose une alternative à la connexion avec FranceConnect")

--- a/backend/app/models/enrollment/hubee_portail.rb
+++ b/backend/app/models/enrollment/hubee_portail.rb
@@ -1,4 +1,6 @@
 class Enrollment::HubeePortail < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def hubee_certdc_status_validated
@@ -25,9 +27,9 @@ class Enrollment::HubeePortail < Enrollment
     errors.add(:dpo_is_informed, :invalid, message: "Vous devez confirmer avoir informé le DPD de votre organisation avant de continuer") unless dpo_is_informed?
     team_members_validation("responsable_metier", "administrateur métier")
     no_hubee_certdc_validation
+  end
 
-    if scopes.empty?
-      errors.add(:scopes, :invalid, message: "Vous devez cocher au moins une démarche en ligne avant de continuer")
-    end
+  def no_scopes_present_error_message
+    "Vous devez cocher au moins un périmètre de données avant de continuer"
   end
 end

--- a/backend/app/models/enrollment/hubee_portail_dila.rb
+++ b/backend/app/models/enrollment/hubee_portail_dila.rb
@@ -1,12 +1,16 @@
 class Enrollment::HubeePortailDila < Enrollment::HubeePortail
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   def submit_validation
     errors.add(:siret, :invalid, message: "Vous devez renseigner un SIRET d’organisation valide avant de continuer") unless nom_raison_sociale
     errors.add(:cgu_approved, :invalid, message: "Vous devez valider les modalités d’utilisation avant de continuer") unless cgu_approved?
     errors.add(:dpo_is_informed, :invalid, message: "Vous devez confirmer avoir informé le DPD de votre organisation avant de continuer") unless dpo_is_informed?
     team_members_validation("responsable_metier", "administrateur métier")
+  end
 
-    if scopes.empty?
-      errors.add(:scopes, :invalid, message: "Vous devez cocher au moins une démarche en ligne avant de continuer")
-    end
+  protected
+
+  def no_scopes_present_error_message
+    "Vous devez cocher au moins une démarche en ligne avant de continuer"
   end
 end

--- a/backend/app/models/enrollment/le_taxi.rb
+++ b/backend/app/models/enrollment/le_taxi.rb
@@ -1,11 +1,12 @@
 class Enrollment::LeTaxi < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+
   protected
 
   def submit_validation
     super
 
     technical_team_validation
-    scopes_validation
     responsable_technique_validation
   end
 end

--- a/backend/app/models/enrollment/mon_compte_pro.rb
+++ b/backend/app/models/enrollment/mon_compte_pro.rb
@@ -1,9 +1,3 @@
 class Enrollment::MonComptePro < Enrollment
-  protected
-
-  def submit_validation
-    super
-
-    scopes_validation
-  end
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
 end

--- a/backend/app/models/enrollment/mon_compte_pro.rb
+++ b/backend/app/models/enrollment/mon_compte_pro.rb
@@ -1,0 +1,9 @@
+class Enrollment::MonComptePro < Enrollment
+  protected
+
+  def submit_validation
+    super
+
+    scopes_validation
+  end
+end

--- a/backend/app/models/enrollment/moncomptepro.rb
+++ b/backend/app/models/enrollment/moncomptepro.rb
@@ -1,3 +1,3 @@
-class Enrollment::MonComptePro < Enrollment
+class Enrollment::Moncomptepro < Enrollment
   include EnrollmentValidators::ValidateAtLeastOneScopePresence
 end

--- a/backend/app/policies/enrollment/api_particulier_policy.rb
+++ b/backend/app/policies/enrollment/api_particulier_policy.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
 class Enrollment::ApiParticulierPolicy < EnrollmentPolicy
+  include PolicyConfigurationFromFile
+
   def revoke?
     record.can_revoke_status? && (user.is_administrator? || user.is_instructor?(record.target_api))
-  end
-
-  def permitted_attributes
-    res = super
-
-    res.concat([
-      scopes: record.configuration["scopesConfiguration"].map { |scope| scope["value"].to_sym }
-    ])
-
-    res
   end
 end

--- a/backend/app/policies/enrollment/mon_compte_pro_policy.rb
+++ b/backend/app/policies/enrollment/mon_compte_pro_policy.rb
@@ -1,3 +1,0 @@
-class Enrollment::MonCompteProPolicy < EnrollmentPolicy
-  include PolicyConfigurationFromFile
-end

--- a/backend/app/policies/enrollment/mon_compte_pro_policy.rb
+++ b/backend/app/policies/enrollment/mon_compte_pro_policy.rb
@@ -1,0 +1,11 @@
+class Enrollment::MonCompteProPolicy < EnrollmentPolicy
+  def permitted_attributes
+    res = super
+
+    res.concat([
+      scopes: record.configuration["scopesConfiguration"].map { |scope| scope["value"].to_sym }
+    ])
+
+    res
+  end
+end

--- a/backend/app/policies/enrollment/mon_compte_pro_policy.rb
+++ b/backend/app/policies/enrollment/mon_compte_pro_policy.rb
@@ -1,11 +1,3 @@
 class Enrollment::MonCompteProPolicy < EnrollmentPolicy
-  def permitted_attributes
-    res = super
-
-    res.concat([
-      scopes: record.configuration["scopesConfiguration"].map { |scope| scope["value"].to_sym }
-    ])
-
-    res
-  end
+  include PolicyConfigurationFromFile
 end

--- a/backend/app/policies/enrollment/moncomptepro_policy.rb
+++ b/backend/app/policies/enrollment/moncomptepro_policy.rb
@@ -1,0 +1,3 @@
+class Enrollment::MoncompteproPolicy < EnrollmentPolicy
+  include PolicyConfigurationFromFile
+end

--- a/backend/app/policies/policy_configuration_from_file.rb
+++ b/backend/app/policies/policy_configuration_from_file.rb
@@ -1,0 +1,13 @@
+module PolicyConfigurationFromFile
+  extend ActiveSupport::Concern
+
+  def permitted_attributes
+    res = super
+
+    res.concat([
+      scopes: record.configuration["scopesConfiguration"].map { |scope| scope["value"].to_sym }
+    ])
+
+    res
+  end
+end

--- a/backend/config/data_providers.yml
+++ b/backend/config/data_providers.yml
@@ -1259,7 +1259,7 @@ shared:
     label: API Satelit (Production)
     mailer: *shared_mailer
 
-  mon_compte_pro:
+  moncomptepro:
     label: MonComptePro
     mailer: *shared_mailer
     reply_to: contact@moncomptepro.beta.gouv.fr

--- a/backend/config/data_providers.yml
+++ b/backend/config/data_providers.yml
@@ -1259,7 +1259,7 @@ shared:
     label: API Satelit (Production)
     mailer: *shared_mailer
 
-  moncomptepro:
+  mon_compte_pro:
     label: MonComptePro
     mailer: *shared_mailer
     reply_to: contact@moncomptepro.beta.gouv.fr

--- a/backend/docs/new_enrollment.md
+++ b/backend/docs/new_enrollment.md
@@ -1,0 +1,34 @@
+# Ajout d'un nouveau fournisseur
+
+Pour un fournisseur `mon_fournisseur`:
+
+1. Inspirez-vous de la configuration pour `mon_compte_pro` ou/et
+   `api_particulier` dans le fichier
+   [data\_providers.yml](../config/data_providers.yml), avec la clé
+   `mon_fournisseur`
+2. Créer le modèle `Enrollment::MonFournisseur` dans `app/models/enrollment` ayant pour
+   structure minimale:
+
+   ```ruby
+   class Enrollment::MonFournisseur < Enrollment
+   end
+   ```
+3. Créer la policy `Enrollment::MonFournisseurPolicy` dans
+   `app/policies/enrollment/` ayant pour structure minimale:
+
+   ```ruby
+   class Enrollment::MonFournisseurPolicy < EnrollmentPolicy
+     include PolicyConfigurationFromFile
+   end
+   ```
+
+Si vous avez des scopes et que au moins l'un d'eux doit être présent: incluez le fichier `EnrollmentValidators::ValidateAtLeastOneScopePresence` dans le modèle de la manière suivante:
+
+```ruby
+class Enrollment::MonFournisseur < Enrollment
+  include EnrollmentValidators::ValidateAtLeastOneScopePresence
+end
+```
+
+Vous pouvez vous inspirer des autres modèles/policies présent dans les dossiers
+pour les configurations.

--- a/cypress/e2e/mon-compte-pro-creation.cy.js
+++ b/cypress/e2e/mon-compte-pro-creation.cy.js
@@ -8,7 +8,7 @@ describe('DataPass', () => {
   // to stay logged in and run several 'it block' without being logged out.
 
   it('lets the user fill a MonComptePro form', () => {
-    cy.visit('http://localhost:3000/mon_compte_pro');
+    cy.visit('http://localhost:3000/moncomptepro');
 
     cy.fillField('intitule', 'Test de soumission de formulaire');
     cy.fillField(

--- a/cypress/e2e/mon-compte-pro-creation.cy.js
+++ b/cypress/e2e/mon-compte-pro-creation.cy.js
@@ -1,0 +1,49 @@
+// By default, Cypress will clear the current session data before each test when testIsolation is enabled
+describe('DataPass', () => {
+  before(() => {
+    cy.login('user@yopmail.com', 'user@yopmail.com');
+  });
+
+  // Cypress removes Cypress.Cookies.preserveOnce("_session_id") since version 10 and no solutions are proposed
+  // to stay logged in and run several 'it block' without being logged out.
+
+  it('lets the user fill a MonComptePro form', () => {
+    cy.visit('http://localhost:3000/mon_compte_pro');
+
+    cy.fillField('intitule', 'Test de soumission de formulaire');
+    cy.fillField(
+      'description',
+      'Le projet sert à tester de bout en bout la soumission de formulaire',
+      'textarea'
+    );
+    cy.checkBox('scopes.email');
+    cy.fillField('data_recipients', 'Le testeur');
+    cy.fillField('data_retention_period', '12');
+    cy.fillField('fondement_juridique_title', 'CRPA L114.8', 'textarea');
+    cy.fillField(
+      'fondement_juridique_url',
+      'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033219997/'
+    );
+
+    cy.fillField('team_members[1].given_name', 'Jean');
+    cy.fillField('team_members[1].family_name', 'Martin');
+    cy.fillField('team_members[1].job', 'Chef');
+    cy.fillField('team_members[1].email', 'jeannot_63@mairie-martin.fr');
+    cy.fillField('team_members[1].phone_number', '0606060606');
+
+    cy.fillField('team_members[2].given_name', 'Jean-Pierre');
+    cy.fillField('team_members[2].family_name', 'Dépého');
+    cy.fillField('team_members[2].job', 'Protecteur de la donnée');
+    cy.fillField('team_members[2].email', 'jp@donnee-protegee.fr');
+    cy.fillField('team_members[2].phone_number', '0606060606');
+
+    cy.get('#Les\\%20personnes\\%20impliqu\\%C3\\%A9es button').click();
+    cy.fillField('team_members[3].phone_number', '0606060606');
+
+    cy.checkBox('cgu_approved');
+    cy.checkBox('dpo_is_informed');
+
+    cy.get('button.fr-icon-checkbox-line').click();
+    cy.contains('En cours');
+  });
+});


### PR DESCRIPTION
* Add missing ruby classes
* Refactor some shared behaviour to make it more readable / maintenable and configurable
* Add some documentation on how to add new provider
* Add minimal E2E test for MCP

Closes https://linear.app/pole-api/issue/DAT-125/etq-u-je-vois-un-formulaire-datapass-mcp-qui-fonctionne