### PR TITLE
Use cloud storage for documents

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -9,6 +9,7 @@ ruby "3.2.2"
 
 gem "carrierwave"
 gem "carrierwave-i18n"
+gem "carrierwave-aws"
 gem "devise"
 gem "dotenv-rails"
 gem "http"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -74,6 +74,22 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.834.0)
+    aws-sdk-core (3.185.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.72.0)
+      aws-sdk-core (~> 3, >= 3.184.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.136.0)
+      aws-sdk-core (~> 3, >= 3.181.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.6)
+    aws-sigv4 (1.6.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     brakeman (5.4.1)
     builder (3.2.4)
@@ -86,6 +102,9 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    carrierwave-aws (1.6.0)
+      aws-sdk-s3 (~> 1.0)
+      carrierwave (>= 2.0, < 4)
     carrierwave-i18n (0.2.0)
     case_transform (0.2)
       activesupport
@@ -171,6 +190,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    jmespath (1.6.2)
     json (2.6.3)
     jsonapi-renderer (0.2.2)
     jwt (2.7.0)
@@ -433,6 +453,7 @@ DEPENDENCIES
   brakeman
   byebug
   carrierwave
+  carrierwave-aws
   carrierwave-i18n
   db-query-matchers
   devise

--- a/backend/app/controllers/documents_controller.rb
+++ b/backend/app/controllers/documents_controller.rb
@@ -9,7 +9,7 @@ class DocumentsController < ApplicationController
     if @document.attachment.present?
       send_file(
         @document.file_content,
-        filename: @document.attachment.file.filename,
+        filename: @document.attachment.file.filename
       )
     else
       render json: {}, status: :not_found

--- a/backend/app/controllers/documents_controller.rb
+++ b/backend/app/controllers/documents_controller.rb
@@ -2,9 +2,17 @@ class DocumentsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @document = authorize Document.find(params[:id]), policy_class: DocumentPolicy
-    send_file(
-      @document.attachment.current_path
-    )
+    @document = Document.find(params[:id])
+
+    authorize @document.attachable, :show? if @document.attachable.is_a?(Enrollment)
+
+    if @document.attachment.present?
+      send_file(
+        @document.file_content,
+        filename: @document.attachment.file.filename,
+      )
+    else
+      render json: {}, status: :not_found
+    end
   end
 end

--- a/backend/app/models/document.rb
+++ b/backend/app/models/document.rb
@@ -12,7 +12,14 @@ class Document < ActiveRecord::Base
   default_scope -> { where(archive: false) }
 
   def file_content
-    File.open(attachment.file.file, "r")
+    if attachment.class.storage == CarrierWave::Storage::AWS
+      tempfile = Tempfile.new
+      tempfile.write(attachment.read)
+      tempfile.rewind
+      tempfile
+    else
+      File.open(attachment.file.file, "r")
+    end
   end
 
   private

--- a/backend/app/models/document.rb
+++ b/backend/app/models/document.rb
@@ -11,6 +11,10 @@ class Document < ActiveRecord::Base
 
   default_scope -> { where(archive: false) }
 
+  def file_content
+    File.open(attachment.file.file, "r")
+  end
+
   private
 
   def content_type_validation

--- a/backend/app/models/document/pdf_document.rb
+++ b/backend/app/models/document/pdf_document.rb
@@ -4,7 +4,7 @@ class Document::PdfDocument < Document
   private
 
   def content_type_validation
-    if attachment&.file && !MagicPdfValidator.new(File.new(attachment.file.file, "r")).valid?
+    if attachment&.file && !MagicPdfValidator.new(file_content).valid?
       errors.add("attachment", :invalid, message: "Format de fichier invalide. Merci de joindre uniquement des documents au format pdf.")
     end
   rescue RuntimeError

--- a/backend/app/models/document/spreadsheet_document.rb
+++ b/backend/app/models/document/spreadsheet_document.rb
@@ -4,7 +4,7 @@ class Document::SpreadsheetDocument < Document
   private
 
   def content_type_validation
-    if attachment&.file && !MagicSpreadsheetValidator.new(File.new(attachment.file.file, "r")).valid?
+    if attachment&.file && !MagicSpreadsheetValidator.new(file_content).valid?
       errors.add("attachment", :invalid, message: "Format de fichier invalide. Merci de joindre uniquement des documents au format xlsx, xls, ods ou sxc.")
     end
   rescue RuntimeError

--- a/backend/app/policies/document_policy.rb
+++ b/backend/app/policies/document_policy.rb
@@ -1,7 +1,0 @@
-class DocumentPolicy < ApplicationPolicy
-  def show?
-    # must be the same policy than enrollment_policy#show?
-    user.is_member?(record.attachable) ||
-      user.is_reporter?(record.attachable)
-  end
-end

--- a/backend/app/serializers/admin_user_serializer.rb
+++ b/backend/app/serializers/admin_user_serializer.rb
@@ -1,3 +1,3 @@
-class AdminUserSerializer < ActiveModel::Serializer
+class AdminUserSerializer < ApplicationSerializer
   attributes :id, :email, :roles
 end

--- a/backend/app/serializers/application_serializer.rb
+++ b/backend/app/serializers/application_serializer.rb
@@ -1,0 +1,2 @@
+class ApplicationSerializer < ActiveModel::Serializer
+end

--- a/backend/app/serializers/application_serializer.rb
+++ b/backend/app/serializers/application_serializer.rb
@@ -1,2 +1,3 @@
 class ApplicationSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
 end

--- a/backend/app/serializers/document_serializer.rb
+++ b/backend/app/serializers/document_serializer.rb
@@ -1,4 +1,4 @@
-class DocumentSerializer < ActiveModel::Serializer
+class DocumentSerializer < ApplicationSerializer
   attributes :id, :created_at, :updated_at, :attachment
 
   attribute :type do

--- a/backend/app/serializers/document_serializer.rb
+++ b/backend/app/serializers/document_serializer.rb
@@ -1,5 +1,5 @@
 class DocumentSerializer < ApplicationSerializer
-  attributes :id, :created_at, :updated_at, :attachment
+  attributes :id, :created_at, :updated_at
 
   attribute :type do
     object.type
@@ -7,5 +7,11 @@ class DocumentSerializer < ApplicationSerializer
 
   attribute :filename do
     object.attachment.file.filename
+  end
+
+  attribute :attachment do
+    {
+      url: document_path(object),
+    }
   end
 end

--- a/backend/app/serializers/document_serializer.rb
+++ b/backend/app/serializers/document_serializer.rb
@@ -11,7 +11,7 @@ class DocumentSerializer < ApplicationSerializer
 
   attribute :attachment do
     {
-      url: document_path(object),
+      url: document_path(object)
     }
   end
 end

--- a/backend/app/serializers/enrollment_email_template_serializer.rb
+++ b/backend/app/serializers/enrollment_email_template_serializer.rb
@@ -1,4 +1,4 @@
-class EnrollmentEmailTemplateSerializer < ActiveModel::Serializer
+class EnrollmentEmailTemplateSerializer < ApplicationSerializer
   attributes :event,
     :sender_email,
     :user_email,

--- a/backend/app/serializers/enrollment_hubee_validated_serializer.rb
+++ b/backend/app/serializers/enrollment_hubee_validated_serializer.rb
@@ -1,4 +1,4 @@
-class EnrollmentHubeeValidatedSerializer < ActiveModel::Serializer
+class EnrollmentHubeeValidatedSerializer < ApplicationSerializer
   attributes :id, :siret, :scopes, :status, :target_api, :updated_at
 
   attribute :scopes do

--- a/backend/app/serializers/enrollment_serializer.rb
+++ b/backend/app/serializers/enrollment_serializer.rb
@@ -1,4 +1,4 @@
-class EnrollmentSerializer < ActiveModel::Serializer
+class EnrollmentSerializer < ApplicationSerializer
   attributes :updated_at, :created_at, :id, :target_api, :previous_enrollment_id, :copied_from_enrollment_id,
     :cgu_approved, :scopes, :team_members, :organization_id, :siret, :nom_raison_sociale, :status, :linked_token_manager_id,
     :additional_content, :intitule, :description, :fondement_juridique_title, :fondement_juridique_url,

--- a/backend/app/serializers/event_serializer.rb
+++ b/backend/app/serializers/event_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EventSerializer < ActiveModel::Serializer
+class EventSerializer < ApplicationSerializer
   attributes :id, :comment, :created_at, :diff, :name, :processed_at, :updated_at
 
   has_one :user

--- a/backend/app/serializers/full_user_serializer.rb
+++ b/backend/app/serializers/full_user_serializer.rb
@@ -1,3 +1,3 @@
-class FullUserSerializer < ActiveModel::Serializer
+class FullUserSerializer < ApplicationSerializer
   attributes :id, :email, :given_name, :family_name, :phone_number, :job, :roles, :organizations
 end

--- a/backend/app/serializers/light_enrollment_serializer.rb
+++ b/backend/app/serializers/light_enrollment_serializer.rb
@@ -1,4 +1,4 @@
-class LightEnrollmentSerializer < ActiveModel::Serializer
+class LightEnrollmentSerializer < ApplicationSerializer
   attributes :id, :updated_at, :nom_raison_sociale, :intitule, :target_api, :status, :demandeurs, :notify_events_from_demandeurs_count, :unprocessed_notify_events_from_demandeurs_count, :zip_code, :consulted_by_instructor, :requested_changes_have_been_done
 
   attribute :acl do

--- a/backend/app/serializers/public_enrollment_list_serializer.rb
+++ b/backend/app/serializers/public_enrollment_list_serializer.rb
@@ -1,4 +1,4 @@
-class PublicEnrollmentListSerializer < ActiveModel::Serializer
+class PublicEnrollmentListSerializer < ApplicationSerializer
   attributes :target_api, :siret, :nom_raison_sociale, :updated_at, :intitule
 
   attribute :responsable_traitement_family_name do

--- a/backend/app/serializers/team_member_serializer.rb
+++ b/backend/app/serializers/team_member_serializer.rb
@@ -1,3 +1,3 @@
-class TeamMemberSerializer < ActiveModel::Serializer
+class TeamMemberSerializer < ApplicationSerializer
   attributes :id, :type, :email
 end

--- a/backend/app/serializers/team_member_with_profile_serializer.rb
+++ b/backend/app/serializers/team_member_with_profile_serializer.rb
@@ -1,4 +1,4 @@
-class TeamMemberWithProfileSerializer < ActiveModel::Serializer
+class TeamMemberWithProfileSerializer < ApplicationSerializer
   attributes :id, :type, :email, :given_name, :family_name, :phone_number, :job
 
   attribute :uid do

--- a/backend/app/serializers/user_enrollment_list_serializer.rb
+++ b/backend/app/serializers/user_enrollment_list_serializer.rb
@@ -1,4 +1,4 @@
-class UserEnrollmentListSerializer < ActiveModel::Serializer
+class UserEnrollmentListSerializer < ApplicationSerializer
   attributes :id,
     :description,
     :nom_raison_sociale,

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
-class UserSerializer < ActiveModel::Serializer
+class UserSerializer < ApplicationSerializer
   attributes :id, :family_name, :given_name, :email
 end

--- a/backend/app/serializers/webhook_enrollment_serializer.rb
+++ b/backend/app/serializers/webhook_enrollment_serializer.rb
@@ -1,4 +1,4 @@
-class WebhookEnrollmentSerializer < ActiveModel::Serializer
+class WebhookEnrollmentSerializer < ApplicationSerializer
   attributes :id,
     :intitule,
     :description,

--- a/backend/app/serializers/webhook_event_serializer.rb
+++ b/backend/app/serializers/webhook_event_serializer.rb
@@ -1,4 +1,4 @@
-class WebhookEventSerializer < ActiveModel::Serializer
+class WebhookEventSerializer < ApplicationSerializer
   attributes :id,
     :name,
     :comment,

--- a/backend/app/serializers/webhook_user_with_profile_serializer.rb
+++ b/backend/app/serializers/webhook_user_with_profile_serializer.rb
@@ -1,3 +1,3 @@
-class WebhookUserWithProfileSerializer < ActiveModel::Serializer
+class WebhookUserWithProfileSerializer < ApplicationSerializer
   attributes :id, :uid, :email, :given_name, :family_name, :phone_number, :job
 end

--- a/backend/app/services/magic_validator.rb
+++ b/backend/app/services/magic_validator.rb
@@ -4,7 +4,7 @@ class MagicValidator
   attr_reader :starting_signature, :trailing_signature
 
   def initialize(file)
-    raise "Expecting a file object as an argument" unless file.is_a?(File)
+    raise "Expecting a file object as an argument" unless [File, Tempfile].any? { |klass| file.is_a?(klass) }
 
     # Ensure there are sufficient number of bytes to determine the
     # signatures. If this check is not present, an empty text file

--- a/backend/app/uploaders/document_uploader.rb
+++ b/backend/app/uploaders/document_uploader.rb
@@ -1,9 +1,6 @@
 class DocumentUploader < CarrierWave::Uploader::Base
-  # Choose what kind of storage to use for this uploader:
   storage :file
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/backend/app/uploaders/document_uploader.rb
+++ b/backend/app/uploaders/document_uploader.rb
@@ -1,6 +1,4 @@
 class DocumentUploader < CarrierWave::Uploader::Base
-  storage :file
-
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/backend/config/brakeman.ignore
+++ b/backend/config/brakeman.ignore
@@ -49,46 +49,23 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "284a45cb0fd6d69ca85ca9f181153eca233008257789f828b70bbc3d0b65e5c4",
+      "fingerprint": "49d68f2e211fbdaa76d8cfdcad13ebdc41b1200525ae7ccf67c1a787ab3f77d9",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/documents_controller.rb",
-      "line": 7,
+      "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(authorize(Document.find(params[:id]), :policy_class => (DocumentPolicy)).attachment.current_path)",
+      "code": "send_file(Document.find(params[:id]).file_content, :filename => Document.find(params[:id]).attachment.file.filename)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "DocumentsController",
         "method": "show"
       },
-      "user_input": "Document.find(params[:id])",
-      "confidence": "Weak",
+      "user_input": "Document.find(params[:id]).file_content",
+      "confidence": "Medium",
       "cwe_id": [
         22
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "4a3052dff719af8ed843d7aa3240956740939ad72c7ae9112aa6f2d46f6ef606",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/filter_service.rb",
-      "line": 94,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "items.joins(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).where(\"#{sanitize_key(filter_item[\"key\"], items.joins(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)}::varchar(255) ~* ?\", (if (is_fuzzy(filter_item[\"key\"], items.joins(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)) then\n  \".*(#{sanitize_value(filter_item[\"value\"])}).*\"\nelse\n  \"^(#{sanitize_value(filter_item[\"value\"])})$\"\nend))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "FilterService",
-        "method": "call"
-      },
-      "user_input": "sanitize_key(filter_item[\"key\"], items.joins(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
       ],
       "note": ""
     },
@@ -210,57 +187,11 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "87e23730910e228db19ab6b88ea4c82c7a42da279f45abed7130133969e89eed",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/filter_service.rb",
-      "line": 66,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "items.includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).where(\"#{sanitize_key(filter_item[\"key\"], items.includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)}::varchar(255) ~* ?\", (if is_fuzzy(filter_item[\"key\"], items.includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name) then\n  \".*(#{sanitize_value(filter_item[\"value\"])}).*\"\nelse\n  \"^(#{sanitize_value(filter_item[\"value\"])})$\"\nend))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "FilterService",
-        "method": "call"
-      },
-      "user_input": "sanitize_key(filter_item[\"key\"], items.includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "8ccf675a315da10b100356bbf8164a85e035fcac95b636c6d106b65066298b91",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/filter_service.rb",
-      "line": 94,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "items.includes(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).where(\"#{sanitize_key(filter_item[\"key\"], items.includes(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)}::varchar(255) ~* ?\", (if (is_fuzzy(filter_item[\"key\"], items.includes(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)) then\n  \".*(#{sanitize_value(filter_item[\"value\"])}).*\"\nelse\n  \"^(#{sanitize_value(filter_item[\"value\"])})$\"\nend))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "FilterService",
-        "method": "call"
-      },
-      "user_input": "sanitize_key(filter_item[\"key\"], items.includes(:team_members).where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "b7589a9098719e90a8505b4ebd8b8ed56820f6e741ce1cf3a8baa7910da8d9cb",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/services/filter_service.rb",
-      "line": 93,
+      "line": 101,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "items.where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).where(\"#{sanitize_key(filter_item[\"key\"], items.where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)}::varchar(255) ~* ?\", (if (is_fuzzy(filter_item[\"key\"], items.where(global_search_query(JSON.parse(params.fetch(:filter, \"[]\")).find do\n (filter_item[\"key\"] == \"global_search\")\n end[\"value\"])).includes(:team_members).joins(:events).where(:events => ({ :name => \"notify\", :processed_at => nil, :is_notify_from_demandeur => true })).table_name)) then\n  \".*(#{sanitize_value(filter_item[\"value\"])}).*\"\nelse\n  \"^(#{sanitize_value(filter_item[\"value\"])})$\"\nend))",
       "render_path": null,
@@ -346,6 +277,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-05-30 15:32:02 +0200",
+  "updated": "2023-10-12 12:14:36 +0200",
   "brakeman_version": "5.4.1"
 }

--- a/backend/config/initializers/carrierwave.rb
+++ b/backend/config/initializers/carrierwave.rb
@@ -1,9 +1,26 @@
+def upload_on_ovh_s3?
+  %w[
+    ovh_access_key_id
+    ovh_secret_access_key
+    ovh_region
+    ovh_bucket
+  ].all? { |key| ENV[key.upcase].present? }
+end
+
 CarrierWave.configure do |config|
-  config.root = if Rails.env.test?
-    Rails.root.join("tmp")
-  elsif ENV["UPLOAD_FOLDER"]
-    Rails.root.join(ENV["UPLOAD_FOLDER"])
+  if upload_on_ovh_s3?
+    config.storage = :aws
+    config.aws_bucket = ENV.fetch("OVH_BUCKET")
+    config.aws_acl = "private"
+
+    config.aws_credentials = {
+      endpoint: "https://s3.#{ENV.fetch("OVH_REGION").downcase}.io.cloud.ovh.net/",
+      access_key_id: ENV.fetch("OVH_ACCESS_KEY_ID"),
+      secret_access_key: ENV.fetch("OVH_SECRET_ACCESS_KEY"),
+      region: ENV.fetch("OVH_REGION").downcase
+    }
   else
-    Rails.root.join("/opt/apps/datapass-backend")
+    config.storage = :file
+    config.root = Rails.env.test? ? Rails.root.join("tmp") : Rails.root.join("public")
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
     get "/insee/categories_juridiques/:id", to: "insee#categories_juridiques", id: /[0-9]{1,4}/
 
     get "/api_gouv/apis", to: "api_gouv#apis"
+
+    resources :documents, only: :show
   end
 
   devise_scope :api do
@@ -53,8 +55,6 @@ Rails.application.routes.draw do
       sessions: "devise/sessions"
     }
   end
-
-  get "/uploads/:model/:type/:mounted_as/:id/:filename", to: "documents#show", constraints: {filename: /[^\/]+/}
 
   authenticate :user, lambda { |u| u.is_administrator? } do
     mount Sidekiq::Web => "/sidekiq"


### PR DESCRIPTION
Storing files on server is not a good practice for a lot of reasons.
This pull request introduces a S3 storage backend for documents, which has replication by design, which makes it resilient.

Some changelogs:

* Recycle old documents route (which is not use by the frontend) to mirror/mask the actual cloud storage url
* Some refactor for content validation (not the same way to read content between file and s3 with carrierwave, dunno why)
* Scout clean with `ApplicationSerializer`