### PR TITLE
Simplify/bugfix how we export enrollments

### DIFF
--- a/backend/app/controllers/enrollments_live_controller.rb
+++ b/backend/app/controllers/enrollments_live_controller.rb
@@ -1,25 +1,11 @@
 class EnrollmentsLiveController < ApplicationController
-  include ActionController::Live
-
   before_action :authenticate_user!
 
   # GET /enrollments/export
   def export
     @enrollments = policy_scope(Enrollment)
 
-    # headers inspired from: https://piotrmurach.com/articles/streaming-large-zip-files-in-rails/
-    response.headers["Content-Disposition"] =
-      %(attachment; filename="export-datapass-#{Date.today}.csv")
-    response.headers["Content-Type"] = "text/csv; charset=utf-8"
-    response.headers.delete("Content-Length")
-    response.headers["Cache-Control"] = "no-cache"
-    response.headers["Last-Modified"] = Time.now.httpdate.to_s
-    response.headers["X-Accel-Buffering"] = "no"
-    response.stream.write CSV.generate_line(Enrollment.csv_attributes)
-    @enrollments.csv_collection.each do |line|
-      response.stream.write CSV.generate_line(line)
-    end
-  ensure
-    response.stream.close
+    send_data @enrollments.to_csv,
+      filename: "export-datapass-#{Date.today}.csv"
   end
 end

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -282,8 +282,8 @@ class Enrollment < ActiveRecord::Base
     "#{ENV.fetch("FRONT_HOST")}/#{target_api.tr("_", "-")}/#{id}"
   end
 
-  def self.csv_attributes
-    %w[
+  def self.to_csv
+    attributes = %w[
       id
       target_api
       created_at
@@ -317,12 +317,12 @@ class Enrollment < ActiveRecord::Base
       copied_from_enrollment_id
       link
     ]
-  end
 
-  def self.csv_collection
-    Enrollment.find_each.lazy.map do |enrollment|
-      csv_attributes.map do |attr|
-        enrollment.send(attr)
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+
+      find_each.lazy.each do |enrollment|
+        csv << attributes.map { |attr| enrollment.send(attr) }
       end
     end
   end

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -270,12 +270,8 @@ RSpec.describe Enrollment, type: :model do
     end
   end
 
-  describe ".csv_collection" do
-    subject do
-      csv_file = CSV.generate_line(enrollments.csv_attributes)
-      csv_file << CSV.generate_line(enrollments.csv_collection.first)
-      csv_file
-    end
+  describe "#to_csv" do
+    subject { enrollments.to_csv }
 
     let!(:enrollments_model) { create_list(:enrollment, 1, :api_entreprise) }
     let(:enrollments) { Enrollment.all }
@@ -293,9 +289,7 @@ RSpec.describe Enrollment, type: :model do
 
     describe "team_members_json entry" do
       subject do
-        csv_file = CSV.generate_line(enrollments.csv_attributes)
-        csv_file << CSV.generate_line(enrollments.csv_collection.first)
-        CSV.parse(csv_file, headers: true).first["team_members_json"]
+        CSV.parse(enrollments.to_csv, headers: true).first["team_members_json"]
       end
 
       it "is a valid json" do
@@ -313,9 +307,7 @@ RSpec.describe Enrollment, type: :model do
 
     describe "scopes entry" do
       subject do
-        csv_file = CSV.generate_line(enrollments.csv_attributes)
-        csv_file << CSV.generate_line(enrollments.csv_collection.first)
-        CSV.parse(csv_file, headers: true).first["scopes"]
+        CSV.parse(enrollments.to_csv, headers: true).first["scopes"]
       end
 
       it "is a valid json" do


### PR DESCRIPTION
Previous version use an overkill approach with websockets, which does not work well with reverse proxy. Moreover, it is a little bit overkill to use this feature with so little data.

In doubt, simplify.