### PR TITLE
API Particulier: send email to responsable technique on validation

### DIFF
--- a/backend/app/mailers/enrollment/api_particulier_mailer.rb
+++ b/backend/app/mailers/enrollment/api_particulier_mailer.rb
@@ -1,0 +1,13 @@
+class Enrollment::ApiParticulierMailer < ActionMailer::Base
+  def validate_for_responsable_technique
+    @enrollment = Enrollment.find(params[:enrollment_id])
+    @responsable_technique = @enrollment.team_members.where(type: "responsable_technique").first
+    @enrollment_show_url = "#{ENV.fetch("FRONT_HOST")}/#{@enrollment.target_api.tr("_", "-")}/#{params[:enrollment_id]}"
+
+    mail(
+      to: [@responsable_technique.email],
+      from: "notifications@api.gouv.fr",
+      subject: "Une demande d'accès à l'API Particulier a été validée"
+    )
+  end
+end

--- a/backend/app/notifiers/api_particulier_notifier.rb
+++ b/backend/app/notifiers/api_particulier_notifier.rb
@@ -4,6 +4,22 @@ class ApiParticulierNotifier < BaseNotifier
   def validate(comment:, current_user:)
     super
 
+    if responsable_technique.present? && responsable_technique.email != demandeur.email
+      Enrollment::ApiParticulierMailer.with(
+        enrollment_id: enrollment.id
+      ).validate_for_responsable_technique.deliver_later
+    end
+
     deliver_event_webhook(__method__)
+  end
+
+  private
+
+  def responsable_technique
+    enrollment.team_members.where(type: "responsable_technique").first
+  end
+
+  def demandeur
+    enrollment.demandeurs.first
   end
 end

--- a/backend/app/views/enrollment/api_particulier_mailer/validate_for_responsable_technique.text.erb
+++ b/backend/app/views/enrollment/api_particulier_mailer/validate_for_responsable_technique.text.erb
@@ -1,0 +1,8 @@
+Bonjour <%= "#{@responsable_technique.given_name} #{@responsable_technique.family_name}" %>,
+
+Vous avez été désigné comme responsable technique pour l'habilitation n°<%= @enrollment.id %> " <%= @enrollment.intitule %> ".
+Celle-ci vient d'être validée par le service juridique d'API Particulier.
+
+Le jeton d’accès a été créé 🔑 et est disponible dans le portail API Particulier à l’adresse suivante https://particulier.api.gouv.fr/compte
+
+Pour consulter cette habilitation, veuillez cliquer sur le lien suivant <%= @enrollment_show_url %>

--- a/backend/spec/notifiers/api_particulier_notifier_spec.rb
+++ b/backend/spec/notifiers/api_particulier_notifier_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe ApiParticulierNotifier, type: :notifier do
+  include ActiveJob::TestHelper
+
+  subject(:notify_validate_event) { described_class.new(enrollment).validate(comment: default_email_content, current_user: user) }
+
+  let(:enrollment) { create(:enrollment, :api_particulier, user:, team_members:) }
+  let(:user) { create(:user) }
+  let(:team_members) do
+    [
+      {
+        type: "responsable_technique",
+        email: responsable_technique_email,
+        phone_number: "0636656565"
+      }
+    ]
+  end
+  let(:default_email_content) { "Contenu de l'email de validation par défaut qui est géré client side" }
+
+  context "when response_technique is also the user (which is the demandeur)" do
+    let(:responsable_technique_email) { user.email }
+
+    it "sends only one email to this user, the default one" do
+      perform_enqueued_jobs { notify_validate_event }
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      mail = ActionMailer::Base.deliveries.last
+
+      expect(mail.to).to eq([user.email])
+      expect(mail.subject).to include("validée")
+      expect(mail.body).to eq(default_email_content)
+    end
+  end
+
+  context "when response_technique is different from the user (which is the demandeur)" do
+    let(:responsable_technique_email) { generate(:email) }
+
+    it "sends two distinct emails, one to the user and one to the response_technique" do
+      perform_enqueued_jobs { notify_validate_event }
+
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+      mails = ActionMailer::Base.deliveries.last(2)
+
+      mail_to_demandeur = mails.find { |mail| mail.to == [user.email] }
+
+      expect(mail_to_demandeur.subject).to include("validée")
+      expect(mail_to_demandeur.body).to eq(default_email_content)
+
+      mail_to_responsable_technique = mails.find { |mail| mail.to == [responsable_technique_email] }
+
+      expect(mail_to_responsable_technique).to be_present
+      expect(mail_to_responsable_technique.subject).to include("validée")
+      expect(mail_to_responsable_technique.body).to include("responsable technique")
+    end
+  end
+end


### PR DESCRIPTION
The email is skipped if the responsable technique and the demandeur are the same user.