### PR TITLE
DAT-138 - Implémentation backend des demandes d’avis

### DIFF
--- a/backend/app/controllers/authenticated_user_controller.rb
+++ b/backend/app/controllers/authenticated_user_controller.rb
@@ -1,0 +1,3 @@
+class AuthenticatedUserController < ApplicationController
+  before_action :authenticate_user!
+end

--- a/backend/app/controllers/available_reporters_controller.rb
+++ b/backend/app/controllers/available_reporters_controller.rb
@@ -1,0 +1,14 @@
+class AvailableReportersController < AuthenticatedUserController
+  def index
+    authorize params[:target_api], policy_class: AvailableReporterPolicy
+
+    render json: available_reporters,
+      status: :ok
+  end
+
+  private
+
+  def available_reporters
+    User.reporters(params[:target_api])
+  end
+end

--- a/backend/app/controllers/data_provider_configurations_controller.rb
+++ b/backend/app/controllers/data_provider_configurations_controller.rb
@@ -1,5 +1,5 @@
-class DataProviderConfigurationsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+class DataProviderConfigurationsController < AuthenticatedUserController
+  skip_before_action :authenticate_user!, only: [:index]
 
   # GET /data_provider_configurations
   def index

--- a/backend/app/controllers/documents_controller.rb
+++ b/backend/app/controllers/documents_controller.rb
@@ -1,6 +1,4 @@
-class DocumentsController < ApplicationController
-  before_action :authenticate_user!
-
+class DocumentsController < AuthenticatedUserController
   def show
     @document = Document.find(params[:id])
 

--- a/backend/app/controllers/enrollments_controller.rb
+++ b/backend/app/controllers/enrollments_controller.rb
@@ -1,8 +1,8 @@
-class EnrollmentsController < ApplicationController
+class EnrollmentsController < AuthenticatedUserController
   RESPONSABLE_TRAITEMENT_LABEL = "responsable de traitement"
   DELEGUE_PROTECTION_DONNEES_LABEL = "délégué à la protection des données"
 
-  before_action :authenticate_user!, except: [:public]
+  skip_before_action :authenticate_user!, only: [:public]
 
   # GET /enrollments
   def index

--- a/backend/app/controllers/enrollments_email_templates_controller.rb
+++ b/backend/app/controllers/enrollments_email_templates_controller.rb
@@ -1,6 +1,4 @@
-class EnrollmentsEmailTemplatesController < ApplicationController
-  before_action :authenticate_user!
-
+class EnrollmentsEmailTemplatesController < AuthenticatedUserController
   def index
     @enrollment = Enrollment.find(params[:id])
     authorize @enrollment, :get_email_templates?

--- a/backend/app/controllers/enrollments_hubee_validated_controller.rb
+++ b/backend/app/controllers/enrollments_hubee_validated_controller.rb
@@ -1,6 +1,4 @@
-class EnrollmentsHubeeValidatedController < ApplicationController
-  before_action :authenticate_user!
-
+class EnrollmentsHubeeValidatedController < AuthenticatedUserController
   def index
     # note that this controller use a custom policy scope based on the siret
     @enrollments = EnrollmentPolicy::OrganizationScope.new(current_user, Enrollment).resolve

--- a/backend/app/controllers/enrollments_live_controller.rb
+++ b/backend/app/controllers/enrollments_live_controller.rb
@@ -1,7 +1,4 @@
-class EnrollmentsLiveController < ApplicationController
-  before_action :authenticate_user!
-
-  # GET /enrollments/export
+class EnrollmentsLiveController < AuthenticatedUserController
   def export
     @enrollments = policy_scope(Enrollment)
 

--- a/backend/app/controllers/events_controller.rb
+++ b/backend/app/controllers/events_controller.rb
@@ -1,7 +1,4 @@
-class EventsController < ApplicationController
-  before_action :authenticate_user!
-
-  # GET /events/most-used-comments
+class EventsController < AuthenticatedUserController
   def most_used_comments
     event = params.fetch(:event, "")
     target_api = params.fetch(:target_api, "")

--- a/backend/app/controllers/opinion_comments_controller.rb
+++ b/backend/app/controllers/opinion_comments_controller.rb
@@ -1,0 +1,31 @@
+class OpinionCommentsController < AuthenticatedUserController
+  def create
+    authorize(opinion, :comment?)
+
+    organizer = CreateOpinionComment.call(
+      opinion: opinion,
+      current_user: current_user,
+      opinion_comment_params: opinion_comment_create_params
+    )
+
+    if organizer.success?
+      render json: opinion, status: :created
+    else
+      render json: organizer.opinion_comment.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def opinion
+    @opinion ||= enrollment.opinions.find(params[:opinion_id])
+  end
+
+  def enrollment
+    @enrollment ||= Enrollment.find(params[:enrollment_id])
+  end
+
+  def opinion_comment_create_params
+    params.require(:opinion_comment).permit(:content)
+  end
+end

--- a/backend/app/controllers/opinion_comments_controller.rb
+++ b/backend/app/controllers/opinion_comments_controller.rb
@@ -15,6 +15,16 @@ class OpinionCommentsController < AuthenticatedUserController
     end
   end
 
+  def destroy
+    opinion_comment = OpinionComment.where(id: params[:id], opinion_id: opinion.id).first
+
+    authorize(opinion_comment, :destroy_comment?, policy_class: OpinionPolicy)
+
+    opinion_comment.destroy!
+
+    render json: opinion
+  end
+
   private
 
   def opinion

--- a/backend/app/controllers/opinions_controller.rb
+++ b/backend/app/controllers/opinions_controller.rb
@@ -31,6 +31,16 @@ class OpinionsController < AuthenticatedUserController
     end
   end
 
+  def destroy
+    opinion = Opinion.includes(:comment).find(params[:id])
+
+    authorize(opinion)
+
+    opinion.destroy
+
+    render json: opinion, status: :ok
+  end
+
   private
 
   def enrollment

--- a/backend/app/controllers/opinions_controller.rb
+++ b/backend/app/controllers/opinions_controller.rb
@@ -2,13 +2,13 @@ class OpinionsController < AuthenticatedUserController
   def index
     authorize(enrollment, policy_class: OpinionPolicy)
 
-    opinions = Opinion.includes(:comments).where(enrollment_id: params[:enrollment_id])
+    opinions = Opinion.includes(:comment).where(enrollment_id: params[:enrollment_id])
 
     render json: opinions, status: :ok
   end
 
   def show
-    opinion = Opinion.includes(:comments).find(params[:id])
+    opinion = Opinion.includes(:comment).find(params[:id])
 
     authorize(opinion)
 

--- a/backend/app/controllers/opinions_controller.rb
+++ b/backend/app/controllers/opinions_controller.rb
@@ -1,0 +1,30 @@
+class OpinionsController < AuthenticatedUserController
+  def create
+    authorize(enrollment, policy_class: OpinionPolicy)
+
+    organizer = CreateOpinion.call(
+      enrollment: enrollment,
+      opinion_params: opinion_create_params,
+      current_user: current_user
+    )
+
+    if organizer.success?
+      render json: organizer.opinion, status: :created
+    else
+      render json: organizer.opinion.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def enrollment
+    @enrollment ||= Enrollment.find(params[:enrollment_id])
+  end
+
+  def opinion_create_params
+    params.require(:opinion).permit(
+      :content,
+      :reporter_id
+    )
+  end
+end

--- a/backend/app/controllers/opinions_controller.rb
+++ b/backend/app/controllers/opinions_controller.rb
@@ -1,4 +1,12 @@
 class OpinionsController < AuthenticatedUserController
+  def show
+    opinion = Opinion.includes(:comments).find(params[:id])
+
+    authorize(opinion)
+
+    render json: opinion, status: :ok
+  end
+
   def create
     authorize(enrollment, policy_class: OpinionPolicy)
 

--- a/backend/app/controllers/opinions_controller.rb
+++ b/backend/app/controllers/opinions_controller.rb
@@ -1,4 +1,12 @@
 class OpinionsController < AuthenticatedUserController
+  def index
+    authorize(enrollment, policy_class: OpinionPolicy)
+
+    opinions = Opinion.includes(:comments).where(enrollment_id: params[:enrollment_id])
+
+    render json: opinions, status: :ok
+  end
+
   def show
     opinion = Opinion.includes(:comments).find(params[:id])
 

--- a/backend/app/controllers/team_members_controller.rb
+++ b/backend/app/controllers/team_members_controller.rb
@@ -1,6 +1,4 @@
-class TeamMembersController < ApplicationController
-  before_action :authenticate_user!
-
+class TeamMembersController < AuthenticatedUserController
   def update
     @team_member = authorize TeamMember.find(params[:id])
 

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
-class UsersController < ApplicationController
-  before_action :authenticate_user!, except: %w[join_organization personal_information]
+class UsersController < AuthenticatedUserController
+  skip_before_action :authenticate_user!, only: %w[join_organization personal_information]
 
   def index
     @users = policy_scope(User).order(:email)

--- a/backend/app/interactors/create_event.rb
+++ b/backend/app/interactors/create_event.rb
@@ -11,8 +11,14 @@ class CreateEvent < ApplicationInteractor
   private
 
   def possible_entity
-    if context.event_name.start_with?("opinion_")
+    if event_name.start_with?("opinion_comment_")
+      context.opinion_comment
+    elsif event_name.start_with?("opinion_")
       context.opinion
     end
+  end
+
+  def event_name
+    context.event_name
   end
 end

--- a/backend/app/interactors/create_event.rb
+++ b/backend/app/interactors/create_event.rb
@@ -3,7 +3,16 @@ class CreateEvent < ApplicationInteractor
     context.event = Event.create!(
       enrollment: context.enrollment,
       user: context.current_user,
-      name: context.event_name
+      name: context.event_name,
+      entity: possible_entity
     )
+  end
+
+  private
+
+  def possible_entity
+    if context.event_name.start_with?("opinion_")
+      context.opinion
+    end
   end
 end

--- a/backend/app/interactors/create_event.rb
+++ b/backend/app/interactors/create_event.rb
@@ -1,0 +1,9 @@
+class CreateEvent < ApplicationInteractor
+  def call
+    context.event = Event.create!(
+      enrollment: context.enrollment,
+      user: context.current_user,
+      name: context.event_name
+    )
+  end
+end

--- a/backend/app/interactors/notify_event.rb
+++ b/backend/app/interactors/notify_event.rb
@@ -1,0 +1,11 @@
+class NotifyEvent < ApplicationInteractor
+  def call
+    enrollment.notify_event(context.event_name, **context.notifier_params)
+  end
+
+  private
+
+  def enrollment
+    context.enrollment
+  end
+end

--- a/backend/app/interactors/opinion/close_active_opinion.rb
+++ b/backend/app/interactors/opinion/close_active_opinion.rb
@@ -1,0 +1,21 @@
+class Opinion::CloseActiveOpinion < ApplicationInteractor
+  def call
+    context.previous_active_opinion = enrollment.active_opinion
+
+    return if context.previous_active_opinion.blank?
+
+    context.previous_active_opinion.update!(open: false)
+  end
+
+  def rollback
+    return if context.previous_active_opinion.blank?
+
+    context.previous_active_opinion.update!(open: true)
+  end
+
+  private
+
+  def enrollment
+    context.enrollment
+  end
+end

--- a/backend/app/interactors/opinion/create_model.rb
+++ b/backend/app/interactors/opinion/create_model.rb
@@ -1,0 +1,15 @@
+class Opinion::CreateModel < ApplicationInteractor
+  def call
+    context.opinion = enrollment.opinions.create!(opinion_params)
+  end
+
+  private
+
+  def enrollment
+    context.enrollment
+  end
+
+  def opinion_params
+    context.opinion_params
+  end
+end

--- a/backend/app/interactors/opinion/create_model.rb
+++ b/backend/app/interactors/opinion/create_model.rb
@@ -13,6 +13,8 @@ class Opinion::CreateModel < ApplicationInteractor
   end
 
   def opinion_params
-    context.opinion_params
+    context.opinion_params.merge(
+      instructor_id: context.current_user.id
+    )
   end
 end

--- a/backend/app/interactors/opinion/create_model.rb
+++ b/backend/app/interactors/opinion/create_model.rb
@@ -1,6 +1,9 @@
 class Opinion::CreateModel < ApplicationInteractor
   def call
-    context.opinion = enrollment.opinions.create!(opinion_params)
+    context.opinion = enrollment.opinions.new(opinion_params)
+    context.opinion.save
+
+    context.fail! unless context.opinion.persisted?
   end
 
   private

--- a/backend/app/interactors/opinion/notify_reporter.rb
+++ b/backend/app/interactors/opinion/notify_reporter.rb
@@ -1,0 +1,11 @@
+class Opinion::NotifyReporter < ApplicationInteractor
+  def call
+    OpinionMailer.with(opinion:).create.deliver_later
+  end
+
+  private
+
+  def opinion
+    context.opinion
+  end
+end

--- a/backend/app/interactors/opinion_comment/create_model.rb
+++ b/backend/app/interactors/opinion_comment/create_model.rb
@@ -1,0 +1,17 @@
+class OpinionComment::CreateModel < ApplicationInteractor
+  def call
+    context.opinion_comment = opinion.comments.create!(opinion_comment_params)
+  end
+
+  private
+
+  def opinion
+    context.opinion
+  end
+
+  def opinion_comment_params
+    context.opinion_comment_params.merge(
+      user: context.current_user
+    )
+  end
+end

--- a/backend/app/interactors/opinion_comment/create_model.rb
+++ b/backend/app/interactors/opinion_comment/create_model.rb
@@ -1,6 +1,12 @@
 class OpinionComment::CreateModel < ApplicationInteractor
   def call
-    context.opinion_comment = opinion.comments.create!(opinion_comment_params)
+    context.opinion_comment = opinion.create_comment(opinion_comment_params)
+
+    context.fail! unless context.opinion_comment.persisted?
+  end
+
+  def rollback
+    context.opinion_comment.destroy
   end
 
   private

--- a/backend/app/interactors/opinion_comment/notify_instructor.rb
+++ b/backend/app/interactors/opinion_comment/notify_instructor.rb
@@ -1,0 +1,11 @@
+class OpinionComment::NotifyInstructor < ApplicationInteractor
+  def call
+    OpinionMailer.with(opinion_comment:).comment.deliver_later
+  end
+
+  private
+
+  def opinion_comment
+    context.opinion_comment
+  end
+end

--- a/backend/app/mailers/enrollment/api_particulier_mailer.rb
+++ b/backend/app/mailers/enrollment/api_particulier_mailer.rb
@@ -2,7 +2,7 @@ class Enrollment::ApiParticulierMailer < ActionMailer::Base
   def validate_for_responsable_technique
     @enrollment = Enrollment.find(params[:enrollment_id])
     @responsable_technique = @enrollment.team_members.where(type: "responsable_technique").first
-    @enrollment_show_url = "#{ENV.fetch("FRONT_HOST")}/#{@enrollment.target_api.tr("_", "-")}/#{params[:enrollment_id]}"
+    @enrollment_show_url = @enrollment.link
 
     mail(
       to: [@responsable_technique.email],

--- a/backend/app/mailers/enrollment_mailer.rb
+++ b/backend/app/mailers/enrollment_mailer.rb
@@ -16,7 +16,7 @@ class EnrollmentMailer < ActionMailer::Base
       @responsable_metier_email = params[:responsable_metier_email]
     end
 
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
     @front_host = ENV.fetch("FRONT_HOST")
 
     @majority_percentile_processing_time_in_days = nil
@@ -41,7 +41,7 @@ class EnrollmentMailer < ActionMailer::Base
     @demandeur_given_name = @enrollment.demandeurs.first.given_name
     @demadeur_family_name = @enrollment.demandeurs.first.family_name
     @message = params[:message]
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: @enrollment.subscribers.pluck(:email),
@@ -56,7 +56,7 @@ class EnrollmentMailer < ActionMailer::Base
     @target_api_label = data_provider_config["label"]
     @enrollment = Enrollment.find(params[:enrollment_id])
     @demandeur_email = @enrollment.demandeurs.pluck(:email).first
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: @enrollment.subscribers.pluck(:email),
@@ -71,7 +71,7 @@ class EnrollmentMailer < ActionMailer::Base
     @target_api_label = data_provider_config["label"]
     @enrollment = Enrollment.find(params[:enrollment_id])
     @demandeur_email = @enrollment.demandeurs.pluck(:email).first
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: @enrollment.subscribers.pluck(:email),
@@ -87,7 +87,7 @@ class EnrollmentMailer < ActionMailer::Base
     @nom_raison_sociale = params[:nom_raison_sociale]
     @previous_enrollment_id = params[:previous_enrollment_id]
     @scopes = params[:scopes]
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: "support.partenaires@franceconnect.gouv.fr",
@@ -102,7 +102,7 @@ class EnrollmentMailer < ActionMailer::Base
   def notification_email_unknown_software
     @target_api_label = data_provider_config["label"]
     @enrollment = Enrollment.find(params[:enrollment_id])
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: "equipe-datapass@api.gouv.fr",

--- a/backend/app/mailers/enrollment_reminder_mailer.rb
+++ b/backend/app/mailers/enrollment_reminder_mailer.rb
@@ -6,7 +6,7 @@ class EnrollmentReminderMailer < ActionMailer::Base
   def reminder_draft_enrollment_email
     @target_api_label = data_provider_config["label"]
     @enrollment = Enrollment.find(params[:enrollment_id])
-    @url = "#{ENV.fetch("FRONT_HOST")}/#{params[:target_api].tr("_", "-")}/#{params[:enrollment_id]}"
+    @url = @enrollment.link
 
     mail(
       to: @enrollment.demandeurs.pluck(:email),

--- a/backend/app/mailers/opinion_mailer.rb
+++ b/backend/app/mailers/opinion_mailer.rb
@@ -8,4 +8,15 @@ class OpinionMailer < ActionMailer::Base
       subject: t(".subject")
     )
   end
+
+  def comment
+    @opinion_comment = params[:opinion_comment]
+    @opinion = @opinion_comment.opinion
+
+    mail(
+      to: [@opinion.instructor.email],
+      from: "notifications@api.gouv.fr",
+      subject: t(".subject", enrollment_intitule: @opinion.enrollment.intitule)
+    )
+  end
 end

--- a/backend/app/mailers/opinion_mailer.rb
+++ b/backend/app/mailers/opinion_mailer.rb
@@ -1,0 +1,11 @@
+class OpinionMailer < ActionMailer::Base
+  def create
+    @opinion = params[:opinion]
+
+    mail(
+      to: [@opinion.reporter.email],
+      from: "notifications@api.gouv.fr",
+      subject: t(".subject")
+    )
+  end
+end

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -42,7 +42,7 @@ class Enrollment < ApplicationRecord
   }
 
   has_many :opinions, dependent: :destroy
-  has_one :active_opinion, -> { where(status: "active") }, class_name: "Opinion"
+  has_one :active_opinion, -> { where(open: true) }, class_name: "Opinion"
 
   state_machine :status, initial: :draft, namespace: "status" do
     state :draft

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -1,5 +1,20 @@
 class Event < ApplicationRecord
-  VALID_NAMES = %w[create update_contacts update archive request_changes notify submit import validate copy refuse revoke reminder reminder_before_archive].freeze
+  VALID_NAMES = %w[
+    create
+    update_contacts
+    update
+    archive
+    request_changes
+    notify
+    submit
+    import
+    validate
+    copy
+    refuse
+    revoke
+    reminder
+    reminder_before_archive
+  ].freeze
   EVENTS_WITH_COMMENT_AS_EMAIL_BODY = %w[refuse request_changes validate revoke].freeze
 
   belongs_to :enrollment

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  EVENT_NAMES = %w[create update_contacts update archive request_changes notify submit import validate copy refuse revoke reminder reminder_before_archive].freeze
+  VALID_NAMES = %w[create update_contacts update archive request_changes notify submit import validate copy refuse revoke reminder reminder_before_archive].freeze
   EVENTS_WITH_COMMENT_AS_EMAIL_BODY = %w[refuse request_changes validate revoke].freeze
 
   belongs_to :enrollment
@@ -28,7 +28,7 @@ class Event < ApplicationRecord
   # ArgumentError:
   #   You tried to define an enum named "name" on the model "Event", but this will generate a class method "create", which is already defined by Active Record.
   def validate_name
-    unless name.in?(EVENT_NAMES)
+    unless name.in?(VALID_NAMES)
       errors.add(:name, :invalid, message: "Une erreur inattendue est survenue: nom d’évènement inconnu")
     end
   end

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -16,6 +16,7 @@ class Event < ApplicationRecord
     reminder_before_archive
 
     opinion_created
+    opinion_comment_created
   ].freeze
   EVENTS_WITH_COMMENT_AS_EMAIL_BODY = %w[refuse request_changes validate revoke].freeze
 
@@ -58,7 +59,9 @@ class Event < ApplicationRecord
   def entity_presence
     return if name.blank?
 
-    if name.start_with?("opinion_")
+    if name.start_with?("opinion_comment_")
+      errors.add(:entity, "doit être un commentaire d'avis") unless entity.is_a?(OpinionComment)
+    elsif name.start_with?("opinion_")
       errors.add(:entity, "doit être un avis") unless entity.is_a?(Opinion)
     end
   end

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -7,8 +7,9 @@ class Event < ApplicationRecord
   belongs_to :user, optional: true
   validates :user, presence: true, if: proc { |event| %w[reminder reminder_before_archive archive].exclude?(event.name) }
 
+  validates :name, presence: true, inclusion: {in: VALID_NAMES}
+
   validate :validate_comment
-  validate :validate_name
 
   before_create :mark_as_notify_from_demandeur
 
@@ -21,15 +22,6 @@ class Event < ApplicationRecord
   def validate_comment
     if (name.in?(EVENTS_WITH_COMMENT_AS_EMAIL_BODY) || name == "notify") && !comment.present?
       errors.add(:comment, :invalid, message: "Vous devez renseigner un commentaire")
-    end
-  end
-
-  # We rather use this validation to control the number of events rather than an enum type because it raises:
-  # ArgumentError:
-  #   You tried to define an enum named "name" on the model "Event", but this will generate a class method "create", which is already defined by Active Record.
-  def validate_name
-    unless name.in?(VALID_NAMES)
-      errors.add(:name, :invalid, message: "Une erreur inattendue est survenue: nom d’évènement inconnu")
     end
   end
 

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -18,6 +18,7 @@ class Event < ApplicationRecord
   EVENTS_WITH_COMMENT_AS_EMAIL_BODY = %w[refuse request_changes validate revoke].freeze
 
   belongs_to :enrollment
+  belongs_to :entity, polymorphic: true, optional: true
 
   belongs_to :user, optional: true
   validates :user, presence: true, if: proc { |event| %w[reminder reminder_before_archive archive].exclude?(event.name) }

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -14,6 +14,8 @@ class Event < ApplicationRecord
     revoke
     reminder
     reminder_before_archive
+
+    opinion_created
   ].freeze
   EVENTS_WITH_COMMENT_AS_EMAIL_BODY = %w[refuse request_changes validate revoke].freeze
 
@@ -26,6 +28,7 @@ class Event < ApplicationRecord
   validates :name, presence: true, inclusion: {in: VALID_NAMES}
 
   validate :validate_comment
+  validate :entity_presence
 
   before_create :mark_as_notify_from_demandeur
 
@@ -49,6 +52,14 @@ class Event < ApplicationRecord
       if demandeurs_ids.include?(user.id)
         self.is_notify_from_demandeur = true
       end
+    end
+  end
+
+  def entity_presence
+    return if name.blank?
+
+    if name.start_with?("opinion_")
+      errors.add(:entity, "doit être un avis") unless entity.is_a?(Opinion)
     end
   end
 end

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -5,6 +5,8 @@ class Opinion < ApplicationRecord
   validates :content, presence: true
   validates :enrollment, presence: true
 
+  has_many :comments, class_name: "OpinionComment", dependent: :destroy
+
   validate :only_one_open_opinion_per_enrollment
 
   def only_one_open_opinion_per_enrollment

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -8,6 +8,8 @@ class Opinion < ApplicationRecord
 
   has_one :comment, class_name: "OpinionComment", dependent: :destroy
 
+  has_many :events, as: :entity, dependent: :destroy
+
   validate :only_one_open_opinion_per_enrollment
   validate :enrollment_reporter_is_valid
 

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -6,7 +6,7 @@ class Opinion < ApplicationRecord
   validates :content, presence: true
   validates :enrollment, presence: true
 
-  has_many :comments, class_name: "OpinionComment", dependent: :destroy
+  has_one :comment, class_name: "OpinionComment", dependent: :destroy
 
   validate :only_one_open_opinion_per_enrollment
   validate :enrollment_reporter_is_valid

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -1,5 +1,6 @@
 class Opinion < ApplicationRecord
   belongs_to :enrollment, required: true
+  belongs_to :reporter, class_name: "User", required: true
 
   validates :open, inclusion: {in: [true, false]}
   validates :content, presence: true
@@ -8,6 +9,7 @@ class Opinion < ApplicationRecord
   has_many :comments, class_name: "OpinionComment", dependent: :destroy
 
   validate :only_one_open_opinion_per_enrollment
+  validate :enrollment_reporter_is_valid
 
   def only_one_open_opinion_per_enrollment
     return unless open
@@ -15,5 +17,13 @@ class Opinion < ApplicationRecord
     if enrollment.opinions.where(open: true).any?
       errors.add(:base, "ne peut pas avoir 2 avis ouverts pour la même demande")
     end
+  end
+
+  def enrollment_reporter_is_valid
+    return unless reporter
+    return unless enrollment
+    return if reporter.is_reporter?(enrollment)
+
+    errors.add(:reporter, "n'est pas autorisé à donner un avis sur cette demande")
   end
 end

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -1,5 +1,7 @@
 class Opinion < ApplicationRecord
   belongs_to :enrollment, required: true
+
+  belongs_to :instructor, class_name: "User", required: true
   belongs_to :reporter, class_name: "User", required: true
 
   validates :open, inclusion: {in: [true, false]}
@@ -31,5 +33,13 @@ class Opinion < ApplicationRecord
     return if reporter.is_reporter?(enrollment)
 
     errors.add(:reporter, "n'est pas autorisé à donner un avis sur cette demande")
+  end
+
+  def enrollment_instructor_is_valid
+    return unless instructor
+    return unless enrollment
+    return if instructor.is_instructor?(enrollment.target_api)
+
+    errors.add(:instructor, "n'est pas autorisé à créer un avis pour cette demande")
   end
 end

--- a/backend/app/models/opinion.rb
+++ b/backend/app/models/opinion.rb
@@ -11,6 +11,10 @@ class Opinion < ApplicationRecord
   validate :only_one_open_opinion_per_enrollment
   validate :enrollment_reporter_is_valid
 
+  def closed?
+    !open
+  end
+
   def only_one_open_opinion_per_enrollment
     return unless open
 

--- a/backend/app/models/opinion_comment.rb
+++ b/backend/app/models/opinion_comment.rb
@@ -7,12 +7,12 @@ class OpinionComment < ApplicationRecord
   validates_uniqueness_of :user_id, scope: :opinion_id
   validates :content, presence: true
 
-  validate :user_is_reporter_or_instructor
+  validate :user_is_opinion_reporter
 
-  def user_is_reporter_or_instructor
+  def user_is_opinion_reporter
     return if user.nil?
-    return if user.is_reporter?(enrollment) || user.is_instructor?(enrollment.target_api)
+    return if user == opinion.reporter
 
-    errors.add(:user, "doit être un reporteur ou un instructeur de la demande")
+    errors.add(:user, "doit être le rapporteur renseigné sur la demande d'opinion")
   end
 end

--- a/backend/app/models/opinion_comment.rb
+++ b/backend/app/models/opinion_comment.rb
@@ -10,6 +10,7 @@ class OpinionComment < ApplicationRecord
   validate :user_is_reporter_or_instructor
 
   def user_is_reporter_or_instructor
+    return if user.nil?
     return if user.is_reporter?(enrollment) || user.is_instructor?(enrollment.target_api)
 
     errors.add(:user, "doit être un reporteur ou un instructeur de la demande")

--- a/backend/app/models/opinion_comment.rb
+++ b/backend/app/models/opinion_comment.rb
@@ -7,6 +7,8 @@ class OpinionComment < ApplicationRecord
   validates_uniqueness_of :user_id, scope: :opinion_id
   validates :content, presence: true
 
+  has_many :events, as: :entity, dependent: :destroy
+
   validate :user_is_opinion_reporter
 
   def user_is_opinion_reporter

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -77,6 +77,10 @@ class User < ApplicationRecord
     roles.include?("administrator")
   end
 
+  def full_name
+    "#{given_name} #{family_name}".strip
+  end
+
   protected
 
   def downcase_email

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
 
   scope :with_at_least_one_role, -> { where("roles <> '{}'") }
 
+  scope :reporters, ->(target_api) { from("users, unnest(roles) role").where("role = :main_role or role like :sub_role", main_role: "#{target_api}:reporter", sub_role: "#{target_api}:%:reporter") }
+
   def self.reconcile(external_user_info)
     user = where(
       email: external_user_info["email"].downcase.strip

--- a/backend/app/organizers/create_opinion.rb
+++ b/backend/app/organizers/create_opinion.rb
@@ -3,7 +3,8 @@ class CreateOpinion < ApplicationOrganizer
     context.event_name = "opinion_created"
   end
 
-  organize Opinion::CreateModel,
+  organize Opinion::CloseActiveOpinion,
+    Opinion::CreateModel,
     CreateEvent,
     Opinion::NotifyReporter
 end

--- a/backend/app/organizers/create_opinion.rb
+++ b/backend/app/organizers/create_opinion.rb
@@ -1,0 +1,9 @@
+class CreateOpinion < ApplicationOrganizer
+  before do
+    context.event_name = "opinion_created"
+  end
+
+  organize Opinion::CreateModel,
+    CreateEvent,
+    Opinion::NotifyReporter
+end

--- a/backend/app/organizers/create_opinion_comment.rb
+++ b/backend/app/organizers/create_opinion_comment.rb
@@ -1,0 +1,9 @@
+class CreateOpinionComment < ApplicationOrganizer
+  before do
+    context.event_name = "opinion_comment_created"
+    context.enrollment = context.opinion.enrollment
+  end
+
+  organize OpinionComment::CreateModel,
+    CreateEvent
+end

--- a/backend/app/organizers/create_opinion_comment.rb
+++ b/backend/app/organizers/create_opinion_comment.rb
@@ -5,5 +5,6 @@ class CreateOpinionComment < ApplicationOrganizer
   end
 
   organize OpinionComment::CreateModel,
-    CreateEvent
+    CreateEvent,
+    OpinionComment::NotifyInstructor
 end

--- a/backend/app/policies/available_reporter_policy.rb
+++ b/backend/app/policies/available_reporter_policy.rb
@@ -1,0 +1,7 @@
+class AvailableReporterPolicy < ApplicationPolicy
+  alias_method :target_api, :record
+
+  def index?
+    user.is_instructor?(target_api)
+  end
+end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -26,4 +26,10 @@ class OpinionPolicy < ApplicationPolicy
   def destroy?
     user.is_instructor?(record.enrollment.target_api)
   end
+
+  def destroy_comment?
+    opinion_comment = record
+
+    opinion_comment.user == user
+  end
 end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -1,0 +1,5 @@
+class OpinionPolicy < ApplicationPolicy
+  def create?
+    user.is_instructor?(record.target_api)
+  end
+end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -2,4 +2,11 @@ class OpinionPolicy < ApplicationPolicy
   def create?
     user.is_instructor?(record.target_api)
   end
+
+  def comment?
+    enrollment = record.enrollment
+
+    user.is_instructor?(enrollment.target_api) ||
+      user.is_reporter?(enrollment)
+  end
 end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -1,4 +1,11 @@
 class OpinionPolicy < ApplicationPolicy
+  def index?
+    enrollment = record
+
+    user.is_instructor?(record.target_api) ||
+      user.is_reporter?(enrollment)
+  end
+
   def show?
     comment?
   end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -1,4 +1,8 @@
 class OpinionPolicy < ApplicationPolicy
+  def show?
+    comment?
+  end
+
   def create?
     user.is_instructor?(record.target_api)
   end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -2,12 +2,15 @@ class OpinionPolicy < ApplicationPolicy
   def index?
     enrollment = record
 
-    user.is_instructor?(record.target_api) ||
+    user.is_instructor?(enrollment.target_api) ||
       user.is_reporter?(enrollment)
   end
 
   def show?
-    comment?
+    enrollment = record.enrollment
+
+    user.is_instructor?(enrollment.target_api) ||
+      user.is_reporter?(enrollment)
   end
 
   def create?
@@ -15,9 +18,6 @@ class OpinionPolicy < ApplicationPolicy
   end
 
   def comment?
-    enrollment = record.enrollment
-
-    user.is_instructor?(enrollment.target_api) ||
-      user.is_reporter?(enrollment)
+    user == record.reporter
   end
 end

--- a/backend/app/policies/opinion_policy.rb
+++ b/backend/app/policies/opinion_policy.rb
@@ -14,10 +14,16 @@ class OpinionPolicy < ApplicationPolicy
   end
 
   def create?
-    user.is_instructor?(record.target_api)
+    enrollment = record
+
+    user.is_instructor?(enrollment.target_api)
   end
 
   def comment?
     user == record.reporter
+  end
+
+  def destroy?
+    user.is_instructor?(record.enrollment.target_api)
   end
 end

--- a/backend/app/queries/enrollment_events_for_user_query.rb
+++ b/backend/app/queries/enrollment_events_for_user_query.rb
@@ -1,0 +1,22 @@
+class EnrollmentEventsForUserQuery
+  attr_reader :enrollment, :user
+
+  def initialize(enrollment, user)
+    @enrollment = enrollment
+    @user = user
+  end
+
+  def perform
+    if user.is_reporter?(enrollment) || user.is_instructor?(enrollment.target_api)
+      base_events
+    else
+      base_events.where.not(name: %w[opinion_created opinion_comment_created])
+    end
+  end
+
+  private
+
+  def base_events
+    enrollment.events
+  end
+end

--- a/backend/app/serializers/enrollment_serializer.rb
+++ b/backend/app/serializers/enrollment_serializer.rb
@@ -15,7 +15,9 @@ class EnrollmentSerializer < ApplicationSerializer
   end
 
   has_many :documents
-  has_many :events
+  has_many :events do
+    EnrollmentEventsForUserQuery.new(object, scope).perform
+  end
 
   attribute :scopes do
     object.scopes.map { |scope| [scope.to_sym, true] }.to_h

--- a/backend/app/serializers/enrollment_serializer.rb
+++ b/backend/app/serializers/enrollment_serializer.rb
@@ -3,10 +3,15 @@ class EnrollmentSerializer < ApplicationSerializer
     :cgu_approved, :scopes, :team_members, :organization_id, :siret, :nom_raison_sociale, :status, :linked_token_manager_id,
     :additional_content, :intitule, :description, :fondement_juridique_title, :fondement_juridique_url,
     :data_recipients, :data_retention_period, :data_retention_comment, :demarche, :technical_team_type, :technical_team_value, :demandeurs,
-    :type_projet, :date_mise_en_production, :volumetrie_approximative, :dpo_is_informed, :notify_events_from_demandeurs_count, :unprocessed_notify_events_from_demandeurs_count, :zip_code, :consulted_by_instructor, :requested_changes_have_been_done
+    :type_projet, :date_mise_en_production, :volumetrie_approximative, :dpo_is_informed, :notify_events_from_demandeurs_count, :unprocessed_notify_events_from_demandeurs_count, :zip_code, :consulted_by_instructor, :requested_changes_have_been_done,
+    :active_opinion_id
 
   has_many :team_members, serializer: TeamMemberWithProfileSerializer do
     object.team_members.order(:id)
+  end
+
+  def active_opinion_id
+    object.active_opinion&.id
   end
 
   has_many :documents

--- a/backend/app/serializers/opinion_comment_serializer.rb
+++ b/backend/app/serializers/opinion_comment_serializer.rb
@@ -1,0 +1,5 @@
+class OpinionCommentSerializer < ApplicationSerializer
+  attributes :id, :content, :created_at, :updated_at
+
+  has_one :user
+end

--- a/backend/app/serializers/opinion_serializer.rb
+++ b/backend/app/serializers/opinion_serializer.rb
@@ -1,0 +1,5 @@
+class OpinionSerializer < ApplicationSerializer
+  attributes :id, :open, :content, :created_at, :updated_at
+
+  belongs_to :reporter
+end

--- a/backend/app/serializers/opinion_serializer.rb
+++ b/backend/app/serializers/opinion_serializer.rb
@@ -2,4 +2,5 @@ class OpinionSerializer < ApplicationSerializer
   attributes :id, :open, :content, :created_at, :updated_at
 
   belongs_to :reporter
+  has_many :comments
 end

--- a/backend/app/serializers/opinion_serializer.rb
+++ b/backend/app/serializers/opinion_serializer.rb
@@ -2,5 +2,5 @@ class OpinionSerializer < ApplicationSerializer
   attributes :id, :open, :content, :created_at, :updated_at
 
   belongs_to :reporter
-  has_many :comments
+  has_one :comment
 end

--- a/backend/app/services/enrollment_email_templates_retriever.rb
+++ b/backend/app/services/enrollment_email_templates_retriever.rb
@@ -58,7 +58,7 @@ class EnrollmentEmailTemplatesRetriever
 
   def variables
     @variables ||= {
-      url: enrollment_url,
+      url: enrollment.link,
       target_api_label: target_api_label,
       front_host: front_host,
       user: user,
@@ -68,10 +68,6 @@ class EnrollmentEmailTemplatesRetriever
       scopes: enrollment.scopes,
       api_manager_url: api_manager_url
     }
-  end
-
-  def enrollment_url
-    "#{front_host}/#{enrollment.target_api.tr("_", "-")}/#{enrollment.id}"
   end
 
   def api_manager_url

--- a/backend/app/views/opinion_mailer/comment.text.erb
+++ b/backend/app/views/opinion_mailer/comment.text.erb
@@ -1,0 +1,9 @@
+<%=
+  t(
+    '.body',
+    instructor_full_name: @opinion.instructor.full_name,
+    enrollment_intitule: @opinion.enrollment.intitule,
+    opinion_comment_content: @opinion_comment.content,
+    enrollment_url: @opinion.enrollment.link
+  )
+%>

--- a/backend/app/views/opinion_mailer/create.text.erb
+++ b/backend/app/views/opinion_mailer/create.text.erb
@@ -1,0 +1,9 @@
+<%=
+  t(
+    '.body',
+    reporter_full_name: @opinion.reporter.full_name,
+    enrollment_intitule: @opinion.enrollment.intitule,
+    opinion_content: @opinion.content,
+    enrollment_url: @opinion.enrollment.link
+  )
+%>

--- a/backend/config/locales/mailers.fr.yml
+++ b/backend/config/locales/mailers.fr.yml
@@ -1,0 +1,15 @@
+fr:
+  opinion_mailer:
+    create:
+      subject: "Votre avis sur une habilitation est attendu"
+      body: |+
+        Bonjour %{reporter_full_name}
+
+        Nous avons besoin de vous pour donner un avis sur l'habilitation %{enrollment_intitule}:
+
+        %{opinion_content}
+
+        Vous pouvez y répondre en vous rendant sur le lien suivant: %{enrollment_url}
+
+        Cordialement.
+

--- a/backend/config/locales/mailers.fr.yml
+++ b/backend/config/locales/mailers.fr.yml
@@ -13,3 +13,17 @@ fr:
 
         Cordialement.
 
+    comment:
+      subject: "Une réponse a été donnée sur la demande d'avis pour l'habilitation ' %{ enrollment_intitule } '"
+      body: |+
+        Bonjour %{instructor_full_name}
+
+        Une réponse à votre demande d'avis a été donnée pour l'habilitation  %{enrollment_intitule}:
+
+        %{opinion_comment_content}
+
+        Vous pouvez la consulter en vous rendant sur le lien suivant: %{enrollment_url}
+
+        Cordialement.
+
+

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       end
 
       resources :opinions, only: [:index, :create, :show, :destroy] do
-        resources :opinion_comments, path: "comments", only: [:create]
+        resources :opinion_comments, path: "comments", only: [:create, :destroy]
       end
     end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
         get :email_templates, to: "enrollments_email_templates#index"
       end
 
-      resources :opinions, only: [:create]
+      resources :opinions, only: [:create] do
+        resources :opinion_comments, path: "comments", only: [:create]
+      end
     end
 
     get "enrollments/:target_api/available_reporters", to: "available_reporters#index"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
         get :email_templates, to: "enrollments_email_templates#index"
       end
+
+      resources :opinions, only: [:create]
     end
 
     get "/data_provider_configurations", to: "data_provider_configurations#index"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         get :email_templates, to: "enrollments_email_templates#index"
       end
 
-      resources :opinions, only: [:create, :show] do
+      resources :opinions, only: [:index, :create, :show] do
         resources :opinion_comments, path: "comments", only: [:create]
       end
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         get :email_templates, to: "enrollments_email_templates#index"
       end
 
-      resources :opinions, only: [:create] do
+      resources :opinions, only: [:create, :show] do
         resources :opinion_comments, path: "comments", only: [:create]
       end
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         get :email_templates, to: "enrollments_email_templates#index"
       end
 
-      resources :opinions, only: [:index, :create, :show] do
+      resources :opinions, only: [:index, :create, :show, :destroy] do
         resources :opinion_comments, path: "comments", only: [:create]
       end
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
       resources :opinions, only: [:create]
     end
 
+    get "enrollments/:target_api/available_reporters", to: "available_reporters#index"
+
     get "/data_provider_configurations", to: "data_provider_configurations#index"
     get "/data_provider_configurations/:target_api", to: "data_provider_configurations#show"
 

--- a/backend/db/migrate/20231023071655_add_polymorphic_entity_to_events.rb
+++ b/backend/db/migrate/20231023071655_add_polymorphic_entity_to_events.rb
@@ -1,0 +1,5 @@
+class AddPolymorphicEntityToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :events, :entity, polymorphic: true
+  end
+end

--- a/backend/db/migrate/20231023122739_add_reporter_to_opinions.rb
+++ b/backend/db/migrate/20231023122739_add_reporter_to_opinions.rb
@@ -1,0 +1,5 @@
+class AddReporterToOpinions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :opinions, :reporter_id, :integer, null: false
+  end
+end

--- a/backend/db/migrate/20231109165754_add_instructor_id_to_opinions.rb
+++ b/backend/db/migrate/20231109165754_add_instructor_id_to_opinions.rb
@@ -1,0 +1,5 @@
+class AddInstructorIdToOpinions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :opinions, :instructor_id, :integer, null: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -67,7 +67,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_122739) do
     t.jsonb "diff"
     t.datetime "processed_at"
     t.boolean "is_notify_from_demandeur", default: false
+    t.string "entity_type"
+    t.bigint "entity_id"
     t.index ["enrollment_id"], name: "index_events_on_enrollment_id"
+    t.index ["entity_type", "entity_id"], name: "index_events_on_entity"
     t.index ["name"], name: "index_events_on_name"
     t.index ["user_id"], name: "index_events_on_user_id"
   end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -91,6 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_122739) do
     t.boolean "open", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "reporter_id", null: false
     t.index ["enrollment_id"], name: "index_opinions_on_enrollment_id"
   end
 

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_122739) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_09_165754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_122739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "reporter_id", null: false
+    t.integer "instructor_id", null: false
     t.index ["enrollment_id"], name: "index_opinions_on_enrollment_id"
   end
 

--- a/backend/spec/controllers/available_reporters_controller_spec.rb
+++ b/backend/spec/controllers/available_reporters_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe AvailableReportersController, type: :controller do
+  describe "#index" do
+    subject(:get_index) { get :index, params: {target_api:} }
+
+    let(:target_api) { :api_particulier }
+
+    before do
+      login(user)
+    end
+
+    let(:user) { create(:user, roles: [role]) }
+    let!(:valid_reporters) { create_list(:reporter, 2, target_api: target_api) }
+
+    context "when user is an instructor for this target api" do
+      let(:role) { "#{target_api}:instructor" }
+
+      it "returns a 200" do
+        get_index
+
+        expect(response.status).to eq(200)
+      end
+
+      it "returns the list of available reporters" do
+        get_index
+
+        expect(JSON.parse(response.body).map { |entity| entity["id"] }.sort).to eq(valid_reporters.pluck(:id).sort)
+      end
+    end
+
+    context "when user is not an instructor for this target api" do
+      let(:role) { "api_particulier:reporter" }
+
+      it "returns a 403" do
+        get_index
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/opinion_comments_controller_spec.rb
+++ b/backend/spec/controllers/opinion_comments_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OpinionCommentsController, type: :controller do
       }
     end
 
-    let(:user) { create(:reporter, target_api: user_target_api) }
+    let(:user) { opinion.reporter }
     let(:enrollment) { create(:enrollment, :api_particulier) }
     let(:opinion) { create(:opinion, enrollment: enrollment) }
     let(:opinion_comment_attributes) { attributes_for(:opinion_comment) }
@@ -20,14 +20,10 @@ RSpec.describe OpinionCommentsController, type: :controller do
     let(:user_target_api) { :api_particulier }
     let(:opinion_attributes) { attributes_for(:opinion_comment) }
 
-    context "when user is a reporter for the target api" do
-      let(:user_target_api) { :api_particulier }
+    it { is_expected.to have_http_status(:success) }
 
-      it { is_expected.to have_http_status(:created) }
-    end
-
-    context "when user is not a reporter for the target api" do
-      let(:user_target_api) { :api_entreprise }
+    context "when user is not the opinion's reporter" do
+      let(:user) { create(:reporter, target_api: :api_particulier) }
 
       it { is_expected.to have_http_status(:forbidden) }
     end

--- a/backend/spec/controllers/opinion_comments_controller_spec.rb
+++ b/backend/spec/controllers/opinion_comments_controller_spec.rb
@@ -28,4 +28,27 @@ RSpec.describe OpinionCommentsController, type: :controller do
       it { is_expected.to have_http_status(:forbidden) }
     end
   end
+
+  describe "DELETE #destroy" do
+    subject(:destroy_opinion_comment) do
+      delete :destroy, params: {
+        enrollment_id: opinion.enrollment_id,
+        opinion_id: opinion.id,
+        id: opinion_comment.id
+      }
+    end
+
+    let(:user) { opinion_comment.user }
+    let(:enrollment) { create(:enrollment, :api_particulier) }
+    let(:opinion) { create(:opinion, enrollment: enrollment) }
+    let(:opinion_comment) { create(:opinion_comment, opinion: opinion) }
+
+    it { is_expected.to have_http_status(:success) }
+
+    context "when user is not the creator" do
+      let(:user) { create(:reporter, target_api: :api_particulier) }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
 end

--- a/backend/spec/controllers/opinion_comments_controller_spec.rb
+++ b/backend/spec/controllers/opinion_comments_controller_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe OpinionCommentsController, type: :controller do
+  before do
+    login(user)
+  end
+
+  describe "POST #create" do
+    subject(:create_opinion_comment) do
+      post :create, params: {
+        enrollment_id: opinion.enrollment_id,
+        opinion_id: opinion.id,
+        opinion_comment: opinion_comment_attributes
+      }
+    end
+
+    let(:user) { create(:reporter, target_api: user_target_api) }
+    let(:enrollment) { create(:enrollment, :api_particulier) }
+    let(:opinion) { create(:opinion, enrollment: enrollment) }
+    let(:opinion_comment_attributes) { attributes_for(:opinion_comment) }
+
+    let(:user_target_api) { :api_particulier }
+    let(:opinion_attributes) { attributes_for(:opinion_comment) }
+
+    context "when user is a reporter for the target api" do
+      let(:user_target_api) { :api_particulier }
+
+      it { is_expected.to have_http_status(:created) }
+    end
+
+    context "when user is not a reporter for the target api" do
+      let(:user_target_api) { :api_entreprise }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
+end

--- a/backend/spec/controllers/opinions_controller_spec.rb
+++ b/backend/spec/controllers/opinions_controller_spec.rb
@@ -142,4 +142,40 @@ RSpec.describe OpinionsController, type: :controller do
       it { is_expected.to have_http_status(:forbidden) }
     end
   end
+
+  describe "#DELETE destroy" do
+    subject(:delete_opinion) do
+      delete :destroy, params: {
+        enrollment_id: enrollment.id,
+        id: opinion.id
+      }
+    end
+
+    let(:enrollment) { create(:enrollment, :api_particulier) }
+    let(:opinion) { create(:opinion, enrollment: enrollment) }
+
+    context "when user is an instructor for the target api" do
+      let(:user) { create(:instructor, target_api: :api_particulier) }
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context "when user is a reporter for the target api" do
+      let(:user) { create(:reporter, target_api: :api_particulier) }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+
+    context "when user is the reporter's opinion" do
+      let(:user) { opinion.reporter }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+
+    context "when user is not an instructor nor a reporter for the target api" do
+      let(:user) { create(:instructor, target_api: :api_entreprise) }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
 end

--- a/backend/spec/controllers/opinions_controller_spec.rb
+++ b/backend/spec/controllers/opinions_controller_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe OpinionsController, type: :controller do
+  let(:user) { create(:user) }
+
+  before do
+    login(user)
+  end
+
+  describe "POST #create" do
+    subject(:create_opinion) do
+      post :create, params: {
+        enrollment_id: enrollment.id,
+        opinion: opinion_attributes
+      }
+    end
+
+    let(:reporter) { create(:reporter, target_api: reporter_target_api) }
+    let(:enrollment) { create(:enrollment, :api_particulier) }
+
+    let(:reporter_target_api) { :api_particulier }
+    let(:opinion_attributes) { attributes_for(:opinion).merge(reporter_id: reporter.id) }
+
+    context "when user is an instructor for the target api" do
+      let(:user) { create(:instructor, target_api: :api_particulier) }
+
+      it { is_expected.to have_http_status(:created) }
+
+      context "when reporter is not a reporter for the target api" do
+        let(:reporter_target_api) { :api_droits_cnam }
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+      end
+
+      context "when opinion content is empty" do
+        let(:opinion_attributes) { attributes_for(:opinion, content: "").merge(reporter_id: reporter.id) }
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+      end
+    end
+
+    context "when user is not an instructor for the target api" do
+      let(:user) { create(:instructor, target_api: :api_droits_cnam) }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+  end
+end

--- a/backend/spec/controllers/opinions_controller_spec.rb
+++ b/backend/spec/controllers/opinions_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe OpinionsController, type: :controller do
         expect(payload).to include("id" => opinion.id)
         expect(payload).to include("content" => opinion.content)
 
-        expect(payload["comments"].count).to eq(1)
+        expect(payload["comment"]).to include("id" => opinion.comment.id)
       end
     end
 

--- a/backend/spec/factories/events.rb
+++ b/backend/spec/factories/events.rb
@@ -63,5 +63,13 @@ FactoryBot.define do
     trait :archive do
       name { "archive" }
     end
+
+    trait :opinion_created do
+      name { "opinion_created" }
+
+      after(:build) do |event|
+        event.entity ||= build(:opinion, enrollment: event.enrollment)
+      end
+    end
   end
 end

--- a/backend/spec/factories/events.rb
+++ b/backend/spec/factories/events.rb
@@ -71,5 +71,18 @@ FactoryBot.define do
         event.entity ||= build(:opinion, enrollment: event.enrollment)
       end
     end
+
+    trait :opinion_comment_created do
+      name { "opinion_comment_created" }
+
+      transient do
+        opinion { nil }
+      end
+
+      after(:build) do |event, evaluator|
+        opinion = evaluator.opinion || build(:opinion, enrollment: event.enrollment)
+        event.entity ||= build(:opinion_comment, opinion:)
+      end
+    end
   end
 end

--- a/backend/spec/factories/opinion_comments.rb
+++ b/backend/spec/factories/opinion_comments.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     end
 
     after(:build) do |opinion_comment, evaluator|
-      opinion_comment.user ||= create(:user, roles: ["#{evaluator.target_api}:reporter"])
       opinion_comment.opinion ||= create(:opinion, enrollment: create(:enrollment, evaluator.target_api))
+      opinion_comment.user ||= opinion_comment.opinion.reporter
     end
   end
 end

--- a/backend/spec/factories/opinions.rb
+++ b/backend/spec/factories/opinions.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :opinion do
     content { "Give me an advice plz" }
     enrollment { create(:enrollment, :api_particulier) }
+
+    after(:build) do |opinion|
+      opinion.reporter ||= build(:reporter, target_api: opinion.enrollment.target_api)
+    end
   end
 end

--- a/backend/spec/factories/opinions.rb
+++ b/backend/spec/factories/opinions.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     after(:build) do |opinion|
       opinion.reporter ||= build(:reporter, target_api: opinion.enrollment.target_api)
+      opinion.instructor ||= build(:instructor, target_api: opinion.enrollment.target_api)
     end
   end
 end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -48,6 +48,20 @@ FactoryBot.define do
       end
     end
 
+    factory :reporter do
+      transient do
+        target_api { "franceconnect" }
+      end
+
+      after(:build) do |instructor, evaluator|
+        instructor.roles ||= []
+
+        %w[reporter].each do |role|
+          instructor.roles << "#{evaluator.target_api}:#{role}"
+        end
+      end
+    end
+
     factory :instructor do
       transient do
         target_api { "franceconnect" }

--- a/backend/spec/interactors/create_event_spec.rb
+++ b/backend/spec/interactors/create_event_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CreateEvent, type: :interactor do
+  subject { described_class.call(enrollment:, current_user:, event_name:) }
+
+  let(:enrollment) { create(:enrollment, :api_entreprise) }
+  let(:current_user) { create(:user) }
+  let(:event_name) { "create" }
+
+  it { is_expected.to be_a_success }
+
+  it { expect(subject.event).to be_a(Event) }
+
+  it "creates an event with valid attributes" do
+    expect {
+      subject
+    }.to change(Event, :count).by(1)
+
+    last_event = Event.last
+
+    expect(last_event.enrollment).to eq(enrollment)
+    expect(last_event.user).to eq(current_user)
+    expect(last_event.name).to eq(event_name)
+  end
+end

--- a/backend/spec/interactors/notify_event_spec.rb
+++ b/backend/spec/interactors/notify_event_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe NotifyEvent, type: :interactor do
+  subject { described_class.call(notify_event_params) }
+
+  let(:notify_event_params) do
+    {
+      enrollment:,
+      event_name: "notify",
+      notifier_params: notifier_method_params
+    }
+  end
+  let(:notifier_method_params) do
+    {
+      comment: "whatever",
+      current_user: create(:user)
+    }
+  end
+  let(:enrollment) { create(:enrollment, :api_entreprise) }
+  let(:notifier) { instance_double(ApiEntrepriseNotifier, notify: true) }
+
+  before do
+    allow(ApiEntrepriseNotifier).to receive(:new).and_return(notifier)
+  end
+
+  it { is_expected.to be_a_success }
+
+  it "calls valid notifier, with valid method and valid params" do
+    subject
+
+    expect(notifier).to have_received(:notify).with(notifier_method_params)
+  end
+end

--- a/backend/spec/mailers/opinion_mailer_spec.rb
+++ b/backend/spec/mailers/opinion_mailer_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe OpinionMailer, type: :mailer do
+  describe "#create" do
+    subject(:mail) { described_class.with(opinion:).create }
+
+    let(:opinion) { create(:opinion) }
+
+    it "renders valid mail" do
+      expect(mail.to).to eq([opinion.reporter.email])
+      expect(mail.subject).to include("avis")
+
+      expect(mail.body).to include("Bonjour #{opinion.reporter.full_name}")
+      expect(mail.body).to include(opinion.content)
+      expect(mail.body).to include(opinion.enrollment.link)
+    end
+  end
+end

--- a/backend/spec/mailers/opinion_mailer_spec.rb
+++ b/backend/spec/mailers/opinion_mailer_spec.rb
@@ -13,4 +13,19 @@ RSpec.describe OpinionMailer, type: :mailer do
       expect(mail.body).to include(opinion.enrollment.link)
     end
   end
+
+  describe "#comment" do
+    subject(:mail) { described_class.with(opinion_comment: opinion_comment).comment }
+
+    let(:opinion_comment) { create(:opinion_comment) }
+
+    it "renders valid mail" do
+      expect(mail.to).to eq([opinion_comment.opinion.instructor.email])
+      expect(mail.subject).to include("réponse")
+
+      expect(mail.body).to include("Bonjour #{opinion_comment.opinion.instructor.full_name}")
+      expect(mail.body).to include(opinion_comment.content)
+      expect(mail.body).to include(opinion_comment.opinion.enrollment.link)
+    end
+  end
 end

--- a/backend/spec/models/event_spec.rb
+++ b/backend/spec/models/event_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Event, type: :model do
       reminder_before_archive
       archive
       opinion_created
+      opinion_comment_created
     ].each do |trait|
       expect(build(:event, trait)).to be_valid
     end
@@ -111,6 +112,30 @@ RSpec.describe Event, type: :model do
 
         context "when entity is an Opinion" do
           let(:entity) { build(:opinion) }
+
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+
+    context "when event has a name related to opinions comments" do
+      let(:event) { build(:event, name: "opinion_comment_created", entity:) }
+
+      context "when entity is not present" do
+        let(:entity) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when entity is present" do
+        context "when entity is not an OpinionComment" do
+          let(:entity) { build(:enrollment) }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when entity is an OpinionComment" do
+          let(:entity) { build(:opinion_comment) }
 
           it { is_expected.to be_valid }
         end

--- a/backend/spec/models/event_spec.rb
+++ b/backend/spec/models/event_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Event, type: :model do
       reminder
       reminder_before_archive
       archive
+      opinion_created
     ].each do |trait|
       expect(build(:event, trait)).to be_valid
     end
@@ -79,6 +80,40 @@ RSpec.describe Event, type: :model do
         subject.mark_as_processed
 
         expect(subject.processed_at).to_not be(nil)
+      end
+    end
+  end
+
+  describe "entity validation" do
+    subject { event }
+
+    context "when event does not require an entity" do
+      let(:event) { build(:event, name: "archive") }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when event has a name related to opinions" do
+      let(:event) { build(:event, name: "opinion_created", entity:) }
+
+      context "when entity is not present" do
+        let(:entity) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when entity is present" do
+        context "when entity is not an Opinion" do
+          let(:entity) { build(:enrollment) }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when entity is an Opinion" do
+          let(:entity) { build(:opinion) }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end

--- a/backend/spec/models/opinion_comment_spec.rb
+++ b/backend/spec/models/opinion_comment_spec.rb
@@ -3,23 +3,19 @@ RSpec.describe OpinionComment, type: :model do
     expect(build(:opinion_comment)).to be_valid
   end
 
-  describe "user roles" do
-    subject { build(:opinion_comment, target_api: :api_particulier, user:) }
+  describe "user validation" do
+    subject { build(:opinion_comment, target_api: :api_particulier, opinion:, user:) }
 
-    context "when user is not a reporter or instructor" do
-      let(:user) { create(:user, roles: ["api_entreprise:admin"]) }
+    let(:opinion) { create(:opinion) }
+
+    context "when user is not the opinion's reporter" do
+      let(:user) { create(:user, roles: ["api_entreprise:reporter"]) }
 
       it { is_expected.not_to be_valid }
     end
 
-    context "when user is a reporter" do
-      let(:user) { create(:user, roles: ["api_particulier:reporter"]) }
-
-      it { is_expected.to be_valid }
-    end
-
-    context "when user is an instructor" do
-      let(:user) { create(:user, roles: ["api_particulier:instructor"]) }
+    context "when user is the opinion's reporter" do
+      let(:user) { opinion.reporter }
 
       it { is_expected.to be_valid }
     end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -148,4 +148,26 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe ".reporters scope" do
+    subject { described_class.reporters(target_api) }
+
+    let(:target_api) { "api_particulier" }
+
+    let!(:valid_reporters) do
+      [
+        create(:user, roles: ["api_particulier:reporter"]),
+        create(:user, roles: ["api_particulier:cnaf:reporter"])
+      ]
+    end
+
+    let!(:invalid_reporters) do
+      [
+        create(:user, roles: ["api_particulier:instructor", "api_entreprise:reporter"]),
+        create(:user, roles: ["api_entreprise:reporter"])
+      ]
+    end
+
+    it { is_expected.to contain_exactly(*valid_reporters) }
+  end
 end

--- a/backend/spec/organizers/create_opinion_comment_spec.rb
+++ b/backend/spec/organizers/create_opinion_comment_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe CreateOpinionComment, type: :organizer do
       expect(last_event.user).to eq(user)
     end
   end
+
+  context "when there is already a comment" do
+    let!(:opinion_comment) { create(:opinion_comment, opinion: opinion, user: user, content: "This is an advice") }
+
+    it { is_expected.to be_a_failure }
+  end
 end

--- a/backend/spec/organizers/create_opinion_comment_spec.rb
+++ b/backend/spec/organizers/create_opinion_comment_spec.rb
@@ -14,26 +14,28 @@ RSpec.describe CreateOpinionComment, type: :organizer do
   let(:enrollment) { create(:enrollment, :api_particulier) }
   let(:user) { create(:user, roles: ["api_particulier:reporter"]) }
 
-  it { is_expected.to be_success }
+  context "with valid params" do
+    it { is_expected.to be_success }
 
-  it "creates a new opinion comment from current user" do
-    expect { create_opinion_comment }.to change(OpinionComment, :count).by(1)
+    it "creates a new opinion comment from current user" do
+      expect { create_opinion_comment }.to change(OpinionComment, :count).by(1)
 
-    last_opinion_comment = OpinionComment.last
+      last_opinion_comment = OpinionComment.last
 
-    expect(last_opinion_comment.user).to eq(user)
-    expect(last_opinion_comment.opinion).to eq(opinion)
-    expect(last_opinion_comment.content).to eq("This is an advice")
-  end
+      expect(last_opinion_comment.user).to eq(user)
+      expect(last_opinion_comment.opinion).to eq(opinion)
+      expect(last_opinion_comment.content).to eq("This is an advice")
+    end
 
-  it "creates an event linked to this opinion comment" do
-    expect { create_opinion_comment }.to change(Event, :count).by(1)
+    it "creates an event linked to this opinion comment" do
+      expect { create_opinion_comment }.to change(Event, :count).by(1)
 
-    last_event = Event.last
+      last_event = Event.last
 
-    expect(last_event.name).to eq("opinion_comment_created")
-    expect(last_event.enrollment).to eq(enrollment)
-    expect(last_event.entity).to be_a(OpinionComment)
-    expect(last_event.user).to eq(user)
+      expect(last_event.name).to eq("opinion_comment_created")
+      expect(last_event.enrollment).to eq(enrollment)
+      expect(last_event.entity).to be_a(OpinionComment)
+      expect(last_event.user).to eq(user)
+    end
   end
 end

--- a/backend/spec/organizers/create_opinion_comment_spec.rb
+++ b/backend/spec/organizers/create_opinion_comment_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe CreateOpinionComment, type: :organizer do
+  subject(:create_opinion_comment) { described_class.call(params) }
+
+  let(:params) do
+    {
+      opinion: opinion,
+      opinion_comment_params: opinion_comment_params,
+      current_user: user
+    }
+  end
+
+  let(:opinion) { create(:opinion, enrollment:) }
+  let(:opinion_comment_params) { {content: "This is an advice"} }
+  let(:enrollment) { create(:enrollment, :api_particulier) }
+  let(:user) { create(:user, roles: ["api_particulier:reporter"]) }
+
+  it { is_expected.to be_success }
+
+  it "creates a new opinion comment from current user" do
+    expect { create_opinion_comment }.to change(OpinionComment, :count).by(1)
+
+    last_opinion_comment = OpinionComment.last
+
+    expect(last_opinion_comment.user).to eq(user)
+    expect(last_opinion_comment.opinion).to eq(opinion)
+    expect(last_opinion_comment.content).to eq("This is an advice")
+  end
+
+  it "creates an event linked to this opinion comment" do
+    expect { create_opinion_comment }.to change(Event, :count).by(1)
+
+    last_event = Event.last
+
+    expect(last_event.name).to eq("opinion_comment_created")
+    expect(last_event.enrollment).to eq(enrollment)
+    expect(last_event.entity).to be_a(OpinionComment)
+    expect(last_event.user).to eq(user)
+  end
+end

--- a/backend/spec/organizers/create_opinion_comment_spec.rb
+++ b/backend/spec/organizers/create_opinion_comment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateOpinionComment, type: :organizer do
   let(:opinion) { create(:opinion, enrollment:) }
   let(:opinion_comment_params) { {content: "This is an advice"} }
   let(:enrollment) { create(:enrollment, :api_particulier) }
-  let(:user) { create(:user, roles: ["api_particulier:reporter"]) }
+  let(:user) { opinion.reporter }
 
   context "with valid params" do
     it { is_expected.to be_success }
@@ -41,6 +41,12 @@ RSpec.describe CreateOpinionComment, type: :organizer do
 
   context "when there is already a comment" do
     let!(:opinion_comment) { create(:opinion_comment, opinion: opinion, user: user, content: "This is an advice") }
+
+    it { is_expected.to be_a_failure }
+  end
+
+  context "when the user is not a reporter" do
+    let(:user) { create(:user) }
 
     it { is_expected.to be_a_failure }
   end

--- a/backend/spec/organizers/create_opinion_spec.rb
+++ b/backend/spec/organizers/create_opinion_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe CreateOpinion, type: :organizer do
+  include ActiveJob::TestHelper
+
+  subject(:create_opinion) { described_class.call(params) }
+
+  let(:params) do
+    {
+      enrollment: enrollment,
+      opinion_params: opinion_params,
+      current_user: user
+    }
+  end
+
+  let(:enrollment) { create(:enrollment, :api_particulier) }
+  let(:opinion_params) { {content: "Give me an advice plz", reporter_id: reporter.id} }
+  let(:reporter) { create(:reporter, target_api: "api_particulier") }
+  let(:user) { create(:user) }
+
+  it { is_expected.to be_success }
+
+  it "creates a new opinion" do
+    expect { create_opinion }.to change(Opinion, :count).by(1)
+
+    last_opinion = Opinion.last
+
+    expect(last_opinion.reporter).to eq(reporter)
+    expect(last_opinion.enrollment).to eq(enrollment)
+    expect(last_opinion.content).to eq("Give me an advice plz")
+  end
+
+  it "creates an event linked to this opinion" do
+    expect { create_opinion }.to change(Event, :count).by(1)
+
+    last_event = Event.last
+
+    expect(last_event.name).to eq("opinion_created")
+    expect(last_event.enrollment).to eq(enrollment)
+    expect(last_event.entity).to be_a(Opinion)
+    expect(last_event.user).to eq(user)
+  end
+
+  it "notifies reporter" do
+    perform_enqueued_jobs do
+      create_opinion
+    end
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+    mail = ActionMailer::Base.deliveries.last
+
+    expect(mail.to).to eq([reporter.email])
+  end
+end

--- a/backend/spec/organizers/create_opinion_spec.rb
+++ b/backend/spec/organizers/create_opinion_spec.rb
@@ -62,4 +62,24 @@ RSpec.describe CreateOpinion, type: :organizer do
       expect(mail.to).to eq([reporter.email])
     end
   end
+
+  context "when there is already an active opinion" do
+    let!(:previous_open_opinion) { create(:opinion, open: true, enrollment: enrollment) }
+
+    it { is_expected.to be_success }
+
+    it "closes the previous active opinion" do
+      expect { create_opinion }.to change { previous_open_opinion.reload.closed? }.from(false).to(true)
+    end
+
+    context "when params are not valid" do
+      let(:opinion_params) { {content: nil} }
+
+      it { is_expected.to be_a_failure }
+
+      it "does not close the previous active opinion" do
+        expect { create_opinion }.not_to change { previous_open_opinion.reload.closed? }
+      end
+    end
+  end
 end

--- a/backend/spec/organizers/create_opinion_spec.rb
+++ b/backend/spec/organizers/create_opinion_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe CreateOpinion, type: :organizer do
       last_opinion = Opinion.last
 
       expect(last_opinion.reporter).to eq(reporter)
+      expect(last_opinion.instructor).to eq(user)
       expect(last_opinion.enrollment).to eq(enrollment)
       expect(last_opinion.content).to eq("Give me an advice plz")
     end

--- a/backend/spec/queries/enrollment_events_for_user_query_spec.rb
+++ b/backend/spec/queries/enrollment_events_for_user_query_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe EnrollmentEventsForUserQuery, type: :query do
+  subject { described_class.new(enrollment, user).perform }
+
+  let(:enrollment) { create(:enrollment, :api_particulier) }
+  let(:user) { create(:user) }
+
+  let!(:basic_events) do
+    [
+      create(:event, :create, enrollment: enrollment),
+      create(:event, :notify, enrollment: enrollment)
+    ]
+  end
+
+  let!(:restricted_events) do
+    [
+      create(:event, :opinion_created, enrollment: enrollment)
+    ]
+  end
+
+  context "when user is an instructor for the target api" do
+    let(:user) { create(:instructor, target_api: :api_particulier) }
+
+    it { is_expected.to be_a(ActiveRecord::Relation) }
+    it { is_expected.to contain_exactly(*(basic_events + restricted_events)) }
+  end
+
+  context "when user is a reporter for the target api" do
+    let(:user) { create(:instructor, target_api: :api_particulier) }
+
+    it { is_expected.to be_a(ActiveRecord::Relation) }
+    it { is_expected.to contain_exactly(*(basic_events + restricted_events)) }
+  end
+
+  context "when user is not related to the target api" do
+    let(:user) { create(:user, roles: []) }
+
+    it { is_expected.to be_a(ActiveRecord::Relation) }
+    it { is_expected.to contain_exactly(*basic_events) }
+  end
+end

--- a/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
@@ -85,6 +85,10 @@ const eventToDisplayableContent = {
     icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
     label: 'a supprimé l’habilitation',
   },
+  [EnrollmentEvent.create_opinion]: {
+    icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
+    label: 'a demandé un avis',
+  },
 };
 
 export const EventItem: React.FC<Event> = ({

--- a/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
@@ -85,10 +85,6 @@ const eventToDisplayableContent = {
     icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
     label: 'a supprimé l’habilitation',
   },
-  [EnrollmentEvent.instruct]: {
-    icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
-    label: 'a instruit l’habilitation',
-  },
 };
 
 export const EventItem: React.FC<Event> = ({

--- a/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
@@ -89,6 +89,10 @@ const eventToDisplayableContent = {
     icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
     label: 'a demandé un avis',
   },
+  [EnrollmentEvent.create_opinion_comment]: {
+    icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
+    label: 'a répondu à un avis',
+  },
 };
 
 export const EventItem: React.FC<Event> = ({

--- a/frontend/src/components/templates/InstructorHome.tsx
+++ b/frontend/src/components/templates/InstructorHome.tsx
@@ -24,7 +24,10 @@ const InstructorHome: React.FC = () => {
 
   useEffect(() => {
     const defaultFilter = [
-      { id: 'status', value: ['submitted', 'changes_requested'] },
+      {
+        id: 'status',
+        value: ['submitted', 'changes_requested', 'opinion_comment_created'],
+      },
     ];
     const formattedApiFilter = [{ id: 'target_api', value: targetApis }];
     const formattedMessagesFilter = [


### PR DESCRIPTION
Le gros du fonctionnel backend est traité dans cette PR. Il y a encore quelques interrogations sur certains mécanismes, mais il s’agit d’un (gros) jet qui va permettre au front de pouvoir commencer l’implémentation fonctionnel à quasiment 100% (les détails fonctionnels finaux n’impacteront que peu les comportements fronts).

### Niveau conception technique
Je n’ai quasiment pas touché les classes existantes et isolé le gros de la logique dans des pattern chain of commands à travers des classes d’interactors. Les controllers sont simples, les modèles s’occupent de l’intégrité, et le fonctionnel de chaque action sont ainsi simples à comprendre et à augmenter.
L’objectif à terme sera de refactor l’existant dans les mêmes logiques pour pouvoir plus facilement testé en isolation les divers composants et ainsi éliminer les divers “god patterns” autour des enrollments: le (très) gros model, les notifiers, les god controllers etc etc.. 

### Pour review
Lire commit / commit, les “Scout commit” peuvent être omis (jusqu'au premier interactor en fait)

Ce qui est important:
* Les policies
* L’intégrité des models
* Les organizers

### I. Liste des changements de l’API

1. La payload Enrollment renvoi un `active_opinion_id`, qui permet d’aller chercher la demande d’opinion active
2. `POST /api/enrollments/:enrollment_id/opinions` => création d’opinion
    * `opinion[content]` => le contenu de la demande d’avis
    * `opinion[reporter_id]` => l’id du reporter
3. `POST /api/enrollments/:enrollment_id/opinions/:opinion_id/comments` => création d’un commentaire d’opinion
    * `opinion_comment[content]` => le contenu du commentaire associé à la demande d’avis
4. `GET /api/enrollments/:enrollment_id/opinions/:id` => Récupération d’une demande d’opinion avec ses commentaires
5. `GET /api/enrollments/:target_api/available_reporters` => Liste des reporters possible pour une demande d’API

Ce qui n’est pas implémenté pour le moment:
1. `DELETE /api/enrollments/:enrollment_id/opinions/:id`
2. `DELETE /api/enrollments/:enrollment_id/opinions/:opinion_id/comments/:id` => Suppression d’un commentaire

### Changements fonctionnels sur l'existant
1. (Frontend) Dans le flux d’activité les 2 nouveaux événements “create opinion” et “create opinion comment” ont été ajouté (côté front)
2. La liste d’événements est filtré en fonction du type de user: si il s’agit du demandeur, les événements liés aux opinions sont retirés de la liste
3. (Frontend) Sur la home de l’instructeur, dans la colonne “Habilitations à instruire” j’ai ajouté les `opinion_comment_created` comment étant à traiter: une réponse a été donnée sur une demande d’avis

### II. Notes/concerns 
1. Pour I.2. on ne gère qu’un seul reporter, le groupe de reporteur arrivera plus tard => permet de simplifier pour ship une version fonctionnelle plus rapidement
2. Pour I.3., je n’ai pas fait de disjonction, lors de la création d’un commentaire sur un avis, si c’était bien le reporter a qui ont avait demandé: j’ai hésité, je préfère une confirmation ici
3. Un commentaire d’opinion peut être fait par un instructeur ou un reporter : c’était dans la logique d’un potentiel ping/pong entre les 2, mais je ne suis plus sûr de la règle exacte ici: combien de ping/pong entre instructeur/reporter ici possible ? Il n’y a actuellement aucune règle précise (mais on peut harden le fonctionnel plus tard ici)
4. Il n’y a pour le moment aucune notification d’envoyé lors de la création d’un commentaire, il faudra voir ce qu’on fait ici
5. Il y a une notion de “marquer l’événement comme traité” sur `submit` et `notify`, je suppose qu’il faut potentiellement faire la même pour les 2 nouveaux événements que j’ai introduit, mais alors 1. je ne sais pas exactement où mettre ça et 2. je ne sais pas à quoi cela sert fonctionnellement. 
6. Je n’ai pas implémenté la suppression des opinions et des commentaires car je ne sais pas exactement ce qu’on doit faire des événements associés: quid ici ? De même, est-ce qu'il s'agit d'un soft ou hard delete ?
7. Je n’ai pas géré les restrictions d’accès aux avis par les autres reporters (ainsi que les events liés à ces avis) : c’est un corolaire de II.2. mais y’a une nuance sur la notion d’events
8. Je n’ai pas du tout géré les administrateurs: quels sont leurs droits exacte vis a vis des demandes d’avis ?