### PR TITLE
Restrict demandeur phone_number check only on first Form render

### DIFF
--- a/frontend/src/components/molecules/AlertMissingPhoneNumber/index.tsx
+++ b/frontend/src/components/molecules/AlertMissingPhoneNumber/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Alert, { AlertType } from '../../atoms/Alert';
+import SoftAlert from '../SoftAlert';
 
 export const AlertMissingPhoneNumber: React.FC = () => (
-  <Alert type={AlertType.warning}>
+  <SoftAlert>
     Un numéro de téléphone est nécessaire : compléter sur{' '}
     <a
       href="https://moncomptepro.beta.gouv.fr/"
@@ -11,7 +11,7 @@ export const AlertMissingPhoneNumber: React.FC = () => (
     >
       Mon Compte Pro
     </a>
-  </Alert>
+  </SoftAlert>
 );
 
 export default AlertMissingPhoneNumber;

--- a/frontend/src/components/molecules/SoftAlert/index.css
+++ b/frontend/src/components/molecules/SoftAlert/index.css
@@ -1,0 +1,8 @@
+.soft-alert {
+  color: #b34000;
+}
+
+.soft-alert .fr-icon-warning-fill {
+  color: #b34000 !important;
+  margin-right: 5px;
+}

--- a/frontend/src/components/molecules/SoftAlert/index.tsx
+++ b/frontend/src/components/molecules/SoftAlert/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './index.css';
+import { WarningIcon } from '../../atoms/icons/fr-fi-icons';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const SoftAlert: React.FC<Props> = ({ children }) => (
+  <div className="soft-alert">
+    <WarningIcon />
+    {children}
+  </div>
+);
+
+export default SoftAlert;


### PR DESCRIPTION
Suite aux discussions dans ce ticket : https://linear.app/pole-api/issue/DAT-160/etq-u-si-je-nai-pas-renseigne-de-numero-de-telephone-dans-mcp-je-vois