### PR TITLE
Webhooks: `model_type` renders enrollment type

### DIFF
--- a/backend/app/serializers/webhook_serializer.rb
+++ b/backend/app/serializers/webhook_serializer.rb
@@ -13,7 +13,7 @@ class WebhookSerializer
     {
       event: event,
       fired_at: now.to_i,
-      model_type: "Pass",
+      model_type:,
       data: {
         pass: enrollment_serialized
       }.merge(extra_data)
@@ -25,6 +25,10 @@ class WebhookSerializer
   end
 
   private
+
+  def model_type
+    enrollment.class.name.gsub("Enrollment::", "").underscore
+  end
 
   def now
     @now ||= Time.now

--- a/backend/docs/webhooks.md
+++ b/backend/docs/webhooks.md
@@ -61,7 +61,7 @@ un json qui est sous le format ci-dessous :
 {
   "event": "refuse",
   "fired_at": 1628253953,
-  "model_type": "Pass",
+  "model_type": "franceconnect",
   "data": {
     "pass": pass_data
   }
@@ -86,8 +86,9 @@ Avec:
   - `delete`: l'habilitation a été supprimée soit par un utilisateur (si la demande étant en draft ou en changes_requested), soit par un administrateur ;
 - `fired_at`, `timestamp`: timestamp correspondant au moment où le webhook a été
   déclenché ;
-- `model_type`, `string`: correspond au modèle de donnée. Pour le moment il n'y
-  a que `Pass` comme valeur
+- `model_type`, `string`: correspond au modèle de donnée. Il s'agit de la nom de
+    du model sous format " underscore ". Par exemple pour
+    `Enrollment::ApiParticulier` il s'agit de `api_particulier`
 - `data`, `json`: données ayant à minima les informations de l’habilitation dans la
   clé `pass`, d'autres clés peuvent être présentes.
   `pass_data` utilise le serializer

--- a/backend/spec/serializers/webhook_serializer_spec.rb
+++ b/backend/spec/serializers/webhook_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe WebhookSerializer, type: :serializer do
         {
           event: event,
           fired_at: Time.now.to_i,
-          model_type: "Pass",
+          model_type: "franceconnect",
           data: {
             pass: enrollment_serialized
           }.merge(extra_data)
@@ -37,7 +37,7 @@ RSpec.describe WebhookSerializer, type: :serializer do
         {
           event: event,
           fired_at: Time.now.to_i,
-          model_type: "Pass",
+          model_type: "franceconnect",
           data: {
             pass: enrollment_serialized
           }.merge(extra_data)


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/DAT-174/preciser-le-formulaire-concerne-dans-le-champ-model-type-des-webhooks