### PR TITLE
Reopen enrollments (backend/front)

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -7,6 +7,7 @@ end
 
 ruby "3.2.2"
 
+gem "active_snapshot"
 gem "carrierwave"
 gem "carrierwave-i18n"
 gem "carrierwave-aws"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -51,6 +51,10 @@ GEM
       activemodel (>= 4.1)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
+    active_snapshot (0.3.2)
+      activerecord
+      activerecord-import
+      railties
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -59,6 +63,8 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
+    activerecord-import (1.5.1)
+      activerecord (>= 4.2)
     activestorage (7.0.8)
       actionpack (= 7.0.8)
       activejob (= 7.0.8)
@@ -474,6 +480,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.14)
+  active_snapshot
   brakeman
   byebug
   carrierwave

--- a/backend/app/controllers/reopen_enrollments_controller.rb
+++ b/backend/app/controllers/reopen_enrollments_controller.rb
@@ -1,0 +1,22 @@
+class ReopenEnrollmentsController < AuthenticatedUserController
+  def update
+    authorize enrollment, :reopen?
+
+    organizer = ReopenEnrollment.call(
+      enrollment: enrollment,
+      user: current_user
+    )
+
+    if organizer.success?
+      render json: enrollment, status: :ok
+    else
+      render json: {errors: organizer.errors}, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def enrollment
+    @enrollment ||= Enrollment.find(params[:id])
+  end
+end

--- a/backend/app/controllers/validated_enrollment_snapshots_controller.rb
+++ b/backend/app/controllers/validated_enrollment_snapshots_controller.rb
@@ -1,0 +1,23 @@
+class ValidatedEnrollmentSnapshotsController < AuthenticatedUserController
+  def show
+    enrollment = Enrollment.find(params[:enrollment_id])
+
+    authorize enrollment
+
+    reified_models = enrollment.snapshots.find(params[:id]).fetch_reified_items
+
+    render json: serialized_data(reified_models),
+      status: :ok
+  end
+
+  def serialized_data(reified_models)
+    ActiveModelSerializers::SerializableResource.new(
+      reified_models[0],
+      scope: current_user,
+      scope_name: :current_user
+    ).serializable_hash
+      .merge(
+        reified_models[1]
+      )
+  end
+end

--- a/backend/app/controllers/validated_enrollment_snapshots_controller.rb
+++ b/backend/app/controllers/validated_enrollment_snapshots_controller.rb
@@ -17,7 +17,7 @@ class ValidatedEnrollmentSnapshotsController < AuthenticatedUserController
       scope_name: :current_user
     ).serializable_hash
       .merge(
-        team_members: reified_models[1]['team_members'].map do |team_member|
+        team_members: reified_models[1]["team_members"].map do |team_member|
           TeamMemberSerializer.new(team_member).serializable_hash
         end
       )

--- a/backend/app/controllers/validated_enrollment_snapshots_controller.rb
+++ b/backend/app/controllers/validated_enrollment_snapshots_controller.rb
@@ -17,7 +17,9 @@ class ValidatedEnrollmentSnapshotsController < AuthenticatedUserController
       scope_name: :current_user
     ).serializable_hash
       .merge(
-        reified_models[1]
+        team_members: reified_models[1]['team_members'].map do |team_member|
+          TeamMemberSerializer.new(team_member).serializable_hash
+        end
       )
   end
 end

--- a/backend/app/controllers/validated_enrollment_snapshots_controller.rb
+++ b/backend/app/controllers/validated_enrollment_snapshots_controller.rb
@@ -18,7 +18,7 @@ class ValidatedEnrollmentSnapshotsController < AuthenticatedUserController
     ).serializable_hash
       .merge(
         team_members: reified_models[1]["team_members"].map do |team_member|
-          TeamMemberSerializer.new(team_member).serializable_hash
+          TeamMemberWithProfileSerializer.new(team_member).serializable_hash
         end
       )
   end

--- a/backend/app/interactors/enrollment/execute_transition.rb
+++ b/backend/app/interactors/enrollment/execute_transition.rb
@@ -1,0 +1,15 @@
+class Enrollment::ExecuteTransition < ApplicationInteractor
+  def call
+    result = context.enrollment.public_send("#{context.enrollment_transition}_status", transition_params)
+    context.fail!(errors: context.enrollment.errors.full_messages) unless result
+  end
+
+  private
+
+  def transition_params
+    {
+      user_id: context.user.id,
+      comment: context.comment
+    }
+  end
+end

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -155,8 +155,12 @@ class Enrollment < ApplicationRecord
   end
 
   def can_reopen?
-    bridge.blank? ||
-      ["franceconnect"].include?(target_api)
+    %w[
+      franceconnect
+      hubee_portail
+      hubee_portail_dila
+      api_captchetat
+    ].exclude?(target_api)
   end
 
   def mark_event_as_processed(event_name)

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -83,7 +83,7 @@ class Enrollment < ApplicationRecord
     end
 
     event :archive do
-      transition from: all - %i[archived validated], to: :archived
+      transition from: all - %i[archived validated], to: :archived, if: ->(enrollment) { !enrollment.reopening? }
     end
 
     event :validate do

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -127,10 +127,13 @@ class Enrollment < ApplicationRecord
     end
 
     after_transition do |enrollment, transition|
+      entity = (transition.event.to_s == "validate") ? enrollment.last_snapshot : nil
+
       enrollment.events.create!(
         name: transition.event.to_s,
         user_id: transition.args[0][:user_id],
-        comment: transition.args[0][:comment]
+        comment: transition.args[0][:comment],
+        entity:
       )
     end
   end

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -142,6 +142,11 @@ class Enrollment < ApplicationRecord
     snapshots.order(created_at: :desc).limit(1).first
   end
 
+  def reopening?
+    last_validated_at.present? &&
+      status != "validated"
+  end
+
   def mark_event_as_processed(event_name)
     unless ["notify", "submit"].include?(event_name)
       raise ArgumentError.new("Invalid event_name. Must be either 'notify' or 'submit'.")

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -98,14 +98,6 @@ class Enrollment < ApplicationRecord
       enrollment.valid?(transition.event.to_sym)
     end
 
-    before_transition do |enrollment, transition|
-      enrollment.events.create!(
-        name: transition.event.to_s,
-        user_id: transition.args[0][:user_id],
-        comment: transition.args[0][:comment]
-      )
-    end
-
     before_transition from: %i[draft changes_requested], to: :submitted do |enrollment|
       if enrollment.technical_team_type == "software_company" && !enrollment.technical_team_value.match?(/^\d{14}$/)
         enrollment.notify_administrators_for_unknown_software_enrollment
@@ -132,6 +124,14 @@ class Enrollment < ApplicationRecord
 
     after_transition from: :submitted, to: :validated do |enrollment|
       enrollment.snapshot!
+    end
+
+    after_transition do |enrollment, transition|
+      enrollment.events.create!(
+        name: transition.event.to_s,
+        user_id: transition.args[0][:user_id],
+        comment: transition.args[0][:comment]
+      )
     end
   end
 

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -91,7 +91,7 @@ class Enrollment < ApplicationRecord
     end
 
     event :reopen do
-      transition from: :validated, to: :draft
+      transition from: :validated, to: :draft, if: ->(enrollment) { enrollment.can_reopen? }
     end
 
     before_transition do |enrollment, transition|
@@ -152,6 +152,11 @@ class Enrollment < ApplicationRecord
   def reopening?
     last_validated_at.present? &&
       status != "validated"
+  end
+
+  def can_reopen?
+    bridge.blank? ||
+      ["franceconnect"].include?(target_api)
   end
 
   def mark_event_as_processed(event_name)

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -83,7 +83,7 @@ class Enrollment < ApplicationRecord
     end
 
     event :archive do
-      transition from: all - [:archived, :validated], to: :archived
+      transition from: all - %i[archived validated], to: :archived
     end
 
     event :validate do
@@ -131,8 +131,8 @@ class Enrollment < ApplicationRecord
 
       enrollment.events.create!(
         name: transition.event.to_s,
-        user_id: transition.args[0][:user_id],
-        comment: transition.args[0][:comment],
+        user_id: transition.args.try(:[], 0).try(:[], :user_id),
+        comment: transition.args.try(:[], 0).try(:[], :comment),
         entity:
       )
     end
@@ -295,11 +295,6 @@ class Enrollment < ApplicationRecord
     end
 
     copied_enrollment
-  end
-
-  def archive!
-    update!(status: "archived")
-    events.create!(name: "archive")
   end
 
   def team_members_json

--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -90,6 +90,10 @@ class Enrollment < ApplicationRecord
       transition from: :submitted, to: :validated
     end
 
+    event :reopen do
+      transition from: :validated, to: :draft
+    end
+
     before_transition do |enrollment, transition|
       enrollment.valid?(transition.event.to_sym)
     end

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -15,6 +15,8 @@ class Event < ApplicationRecord
     reminder
     reminder_before_archive
 
+    reopen
+
     opinion_created
     opinion_comment_created
   ].freeze

--- a/backend/app/models/team_member.rb
+++ b/backend/app/models/team_member.rb
@@ -6,6 +6,10 @@ class TeamMember < ApplicationRecord
       "TeamMember::#{type.underscore.classify}".constantize
     end
 
+    def sti_class_for(type)
+      find_sti_class(type)
+    end
+
     # ex: > TeamMember::ResponsableTechnique => 'responsable_technique'
     def sti_name
       name.demodulize.underscore

--- a/backend/app/organizers/reopen_enrollment.rb
+++ b/backend/app/organizers/reopen_enrollment.rb
@@ -1,0 +1,7 @@
+class ReopenEnrollment < ApplicationOrganizer
+  before do
+    context.enrollment_transition = "reopen"
+  end
+
+  organize Enrollment::ExecuteTransition
+end

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -90,6 +90,11 @@ class EnrollmentPolicy < ApplicationPolicy
     user.is_instructor?(record.target_api)
   end
 
+  def reopen?
+    record.status == "validated" &&
+      user.is_demandeur?(record)
+  end
+
   def augment_permitted_attributes(attributes, key, *new_values)
     attribute_hash = attributes.find { |attribute| attribute.is_a?(Hash) && attribute.key?(key) }
     attribute_hash[key] += new_values

--- a/backend/app/serializers/enrollment_serializer.rb
+++ b/backend/app/serializers/enrollment_serializer.rb
@@ -36,4 +36,12 @@ class EnrollmentSerializer < ApplicationSerializer
   attribute :requested_changes_have_been_done do
     object.requested_changes_have_been_done?
   end
+
+  attribute :reopening do
+    object.reopening?
+  end
+
+  attribute :can_reopen do
+    object.can_reopen?
+  end
 end

--- a/backend/app/serializers/event_serializer.rb
+++ b/backend/app/serializers/event_serializer.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class EventSerializer < ApplicationSerializer
-  attributes :id, :comment, :created_at, :diff, :name, :processed_at, :updated_at
+  attributes :id,
+    :comment,
+    :created_at,
+    :diff,
+    :name,
+    :processed_at,
+    :updated_at
 
   has_one :user
 end

--- a/backend/app/serializers/event_serializer.rb
+++ b/backend/app/serializers/event_serializer.rb
@@ -6,6 +6,8 @@ class EventSerializer < ApplicationSerializer
     :created_at,
     :diff,
     :name,
+    :entity_id,
+    :entity_type,
     :processed_at,
     :updated_at
 

--- a/backend/app/serializers/user_enrollment_list_serializer.rb
+++ b/backend/app/serializers/user_enrollment_list_serializer.rb
@@ -14,4 +14,8 @@ class UserEnrollmentListSerializer < ApplicationSerializer
       [method.to_s.delete("?"), object.policy.new(current_user, object).send(method)]
     }.to_h
   end
+
+  attribute :reopening do
+    object.reopening?
+  end
 end

--- a/backend/app/serializers/user_enrollment_list_serializer.rb
+++ b/backend/app/serializers/user_enrollment_list_serializer.rb
@@ -18,4 +18,8 @@ class UserEnrollmentListSerializer < ApplicationSerializer
   attribute :reopening do
     object.reopening?
   end
+
+  attribute :can_reopen do
+    object.can_reopen?
+  end
 end

--- a/backend/app/workers/schedule_enrollments_archiveable_worker.rb
+++ b/backend/app/workers/schedule_enrollments_archiveable_worker.rb
@@ -6,6 +6,6 @@ class ScheduleEnrollmentsArchiveableWorker < ApplicationWorker
   sidekiq_options queue: "archive"
 
   def perform
-    EnrollmentsExtractor::ToArchive.new.call.map(&:archive!)
+    EnrollmentsExtractor::ToArchive.new.call.map(&:archive_status)
   end
 end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -84,6 +84,30 @@ module DataPass
 
     # fix paper_trail error: "Tried to load unspecified class: ActiveSupport::TimeWithZone"
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, Time, Date]
+
+    config.after_initialize do
+      ActiveSnapshot.config do |config|
+        config.storage_method = "native_json"
+      end
+
+      Dir[Rails.root.join("app/models/enrollment/*.rb")].each do |file|
+        load file
+      end
+
+      Enrollment.descendants.each do |klass|
+        klass.include ActiveSnapshot
+
+        klass.class_eval do
+          has_snapshot_children do
+            instance = self.class.includes(:team_members).find(id)
+
+            {
+              team_members: instance.team_members
+            }
+          end
+        end
+      end
+    end
   end
 end
 

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -86,10 +86,6 @@ module DataPass
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, Time, Date]
 
     config.after_initialize do
-      ActiveSnapshot.config do |config|
-        config.storage_method = "native_json"
-      end
-
       Dir[Rails.root.join("app/models/enrollment/*.rb")].each do |file|
         load file
       end

--- a/backend/config/initializers/active_snapshot.rb
+++ b/backend/config/initializers/active_snapshot.rb
@@ -1,0 +1,5 @@
+ActiveSupport.on_load(:active_record) do
+  ActiveSnapshot.config do |config|
+    config.storage_method = "native_json"
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :reopen_enrollments, only: [:update]
+
     get "enrollments/:target_api/available_reporters", to: "available_reporters#index"
 
     get "/data_provider_configurations", to: "data_provider_configurations#index"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
         get :email_templates, to: "enrollments_email_templates#index"
       end
 
+      resources :validated_enrollment_snapshots, only: [:show], path: "validated"
+
       resources :opinions, only: [:index, :create, :show, :destroy] do
         resources :opinion_comments, path: "comments", only: [:create, :destroy]
       end

--- a/backend/db/migrate/20231123150149_create_snapshots_tables.rb
+++ b/backend/db/migrate/20231123150149_create_snapshots_tables.rb
@@ -1,0 +1,26 @@
+class CreateSnapshotsTables < ActiveRecord::Migration::Current
+  def change
+    create_table :snapshots do |t|
+      t.belongs_to :item, polymorphic: true, null: false, index: true
+      t.belongs_to :user, polymorphic: true
+
+      t.string :identifier, index: true
+      t.index [:identifier, :item_id, :item_type], unique: true
+
+      t.jsonb :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :snapshot_items do |t|
+      t.belongs_to :snapshot, null: false, index: true
+      t.belongs_to :item, polymorphic: true, null: false, index: true
+      t.index [:snapshot_id, :item_id, :item_type], unique: true
+
+      t.jsonb :object, null: false
+
+      t.datetime :created_at, null: false
+      t.string :child_group_name
+    end
+  end
+end

--- a/backend/db/migrate/20231123150150_add_last_validated_at_and_snapshots_to_enrollments.rb
+++ b/backend/db/migrate/20231123150150_add_last_validated_at_and_snapshots_to_enrollments.rb
@@ -1,0 +1,14 @@
+class AddLastValidatedAtAndSnapshotsToEnrollments < ActiveRecord::Migration[7.0]
+  def up
+    add_column :enrollments, :last_validated_at, :datetime
+
+    Enrollment.where(status: "validated").update_all("last_validated_at = updated_at")
+    Enrollment.where(status: "validated").find_each do |enrollment|
+      enrollment.snapshot!
+    end
+  end
+
+  def down
+    remove_column :enrollments, :last_validated_at, :datetime
+  end
+end

--- a/backend/db/migrate/20231123150150_add_last_validated_at_and_snapshots_to_enrollments.rb
+++ b/backend/db/migrate/20231123150150_add_last_validated_at_and_snapshots_to_enrollments.rb
@@ -3,9 +3,8 @@ class AddLastValidatedAtAndSnapshotsToEnrollments < ActiveRecord::Migration[7.0]
     add_column :enrollments, :last_validated_at, :datetime
 
     Enrollment.where(status: "validated").update_all("last_validated_at = updated_at")
-    Enrollment.where(status: "validated").find_each do |enrollment|
-      enrollment.snapshot!
-    end
+
+    print "Please run specific migration to create snapshots for each validated enrollment: https://gist.github.com/skelz0r/f0124ebff0922f6d6eb209ee50dbbbf9\n"
   end
 
   def down

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_09_165754) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_150150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_165754) do
     t.string "technical_team_type"
     t.string "technical_team_value"
     t.string "zip_code"
+    t.datetime "last_validated_at"
     t.index ["copied_from_enrollment_id"], name: "index_enrollments_on_copied_from_enrollment_id"
   end
 
@@ -112,6 +113,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_165754) do
     t.bigint "organization_id", null: false
     t.index ["organization_id"], name: "index_organizations_users_on_organization_id"
     t.index ["user_id"], name: "index_organizations_users_on_user_id"
+  end
+
+  create_table "snapshot_items", force: :cascade do |t|
+    t.bigint "snapshot_id", null: false
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.jsonb "object", null: false
+    t.datetime "created_at", null: false
+    t.string "child_group_name"
+    t.index ["item_type", "item_id"], name: "index_snapshot_items_on_item"
+    t.index ["snapshot_id", "item_id", "item_type"], name: "index_snapshot_items_on_snapshot_id_and_item_id_and_item_type", unique: true
+    t.index ["snapshot_id"], name: "index_snapshot_items_on_snapshot_id"
+  end
+
+  create_table "snapshots", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "user_type"
+    t.bigint "user_id"
+    t.string "identifier"
+    t.jsonb "metadata"
+    t.datetime "created_at", null: false
+    t.index ["identifier", "item_id", "item_type"], name: "index_snapshots_on_identifier_and_item_id_and_item_type", unique: true
+    t.index ["identifier"], name: "index_snapshots_on_identifier"
+    t.index ["item_type", "item_id"], name: "index_snapshots_on_item"
+    t.index ["user_type", "user_id"], name: "index_snapshots_on_user"
   end
 
   create_table "team_members", force: :cascade do |t|

--- a/backend/spec/controllers/enrollments/change_state_spec.rb
+++ b/backend/spec/controllers/enrollments/change_state_spec.rb
@@ -856,6 +856,18 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
         it { is_expected.to have_http_status(:ok) }
       end
 
+      context "when enrollment has been reopened" do
+        let(:enrollment_status) { :validated }
+
+        before do
+          login(user)
+
+          ReopenEnrollment.call(enrollment:, user: enrollment.demandeurs.first.user)
+        end
+
+        it { is_expected.to have_http_status(:forbidden) }
+      end
+
       context "for a revoked enrollment" do
         let(:enrollment_status) { :revoked }
 

--- a/backend/spec/controllers/enrollments/change_state_spec.rb
+++ b/backend/spec/controllers/enrollments/change_state_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
         expect(FranceconnectBridge).to have_received(:call)
       end
 
-      it "tracks event as validate for this enrollment" do
+      it "tracks event as validate for this enrollment, and associate snapshot record for history" do
         expect {
           make_request
         }.to change { enrollment.events.reload.count }.by(1)
@@ -419,6 +419,7 @@ RSpec.describe EnrollmentsController, "#change_state", type: :controller do
 
         expect(last_enrollment_event.user).to eq(user)
         expect(last_enrollment_event.name).to eq("validate")
+        expect(last_enrollment_event.entity).to be_a(ActiveSnapshot::Snapshot)
       end
 
       describe "emails send" do

--- a/backend/spec/controllers/reopen_enrollments_controller_spec.rb
+++ b/backend/spec/controllers/reopen_enrollments_controller_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe ReopenEnrollmentsController, type: :controller do
+  describe "#update" do
+    subject(:update) { put :update, params: {id: enrollment.id} }
+
+    let(:enrollment) do
+      create(
+        :enrollment,
+        enrollment_status,
+        :api_particulier,
+        organization_kind: :clamart
+      )
+    end
+    let(:enrollment_status) { :validated }
+    let(:user) { enrollment.demandeurs.first.user }
+
+    describe "authorization" do
+      context "without user" do
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context "with user" do
+        before do
+          login(user)
+        end
+
+        context "when user is the enrollment's creator" do
+          context "when enrollment is in validated" do
+            it { is_expected.to have_http_status(:ok) }
+          end
+
+          context "when enrollment is in draft mode" do
+            let(:enrollment_status) { :draft }
+
+            it { is_expected.to have_http_status(:forbidden) }
+          end
+        end
+
+        context "when user is not the enrollment's creator" do
+          let(:user) { create(:user, email_verified: true, organization_kind: :clamart) }
+
+          it { is_expected.to have_http_status(:forbidden) }
+        end
+      end
+    end
+
+    describe "behavior" do
+      before do
+        login(user)
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it "reopens the enrollment" do
+        expect {
+          update
+        }.to change { enrollment.reload.status }.to("draft")
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
+++ b/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
@@ -85,25 +85,33 @@ RSpec.describe ValidatedEnrollmentSnapshotsController, type: :controller, versio
     end
 
     let(:enrollment) do
+      original_enrollment.update!(intitule: "old intitule")
+      original_enrollment.team_members.first.update!(given_name: "old given name")
+
       original_enrollment.snapshot!
+
       original_enrollment.update!(intitule: "new intitule")
       original_enrollment.team_members.first.update!(given_name: "new given name")
+
       original_enrollment
     end
 
     let(:snapshot) { enrollment.last_snapshot }
-    let(:original_enrollment) { create(:enrollment, :franceconnect, user: user) }
+    let(:original_enrollment) { create(:enrollment, :franceconnect, :validated, user: user) }
     let(:user) { create(:user) }
 
     before do
       login(user)
     end
 
-    it "renders the snapshot version" do
+    it "renders the snapshot version, with team members with full profile" do
       expect(show_enrollment_payload["intitule"]).not_to eq("new intitule")
       expect(show_enrollment_payload["team_members"][0]["given_name"]).not_to eq("new given name")
 
-      expect(show_enrollment_payload["team_members"][0]["type"]).to eq("demandeur")
+      expect(show_enrollment_payload["intitule"]).to eq("old intitule")
+      expect(show_enrollment_payload["team_members"][0]["given_name"]).to eq("old given name")
+
+      expect(show_enrollment_payload["team_members"][0]["type"]).to be_present
     end
   end
 end

--- a/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
+++ b/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe ValidatedEnrollmentSnapshotsController, type: :controller, versio
     it "renders the snapshot version" do
       expect(show_enrollment_payload["intitule"]).not_to eq("new intitule")
       expect(show_enrollment_payload["team_members"][0]["given_name"]).not_to eq("new given name")
+
+      expect(show_enrollment_payload["team_members"][0]["type"]).to eq("demandeur")
     end
   end
 end

--- a/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
+++ b/backend/spec/controllers/validated_enrollment_snapshots_controller_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe ValidatedEnrollmentSnapshotsController, type: :controller, versioning: true do
+  describe "authorization" do
+    subject do
+      get :show, params: {
+        enrollment_id: enrollment.id,
+        id: snapshot.id
+      }
+    end
+
+    let(:snapshot) { enrollment.last_snapshot }
+    let(:enrollment) do
+      original_enrollment.snapshot!
+      original_enrollment
+    end
+
+    context "without user" do
+      let(:original_enrollment) { create(:enrollment, :franceconnect) }
+
+      it { is_expected.to have_http_status(:unauthorized) }
+    end
+
+    context "with user" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+      end
+
+      context "when user created this enrollment" do
+        let(:original_enrollment) { create(:enrollment, :franceconnect, user: user) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+
+      context "when user is the delegue_protection_donnees associated to this enrollment" do
+        let(:original_enrollment) { create(:enrollment, :franceconnect, delegue_protection_donnees: build(:team_member, :delegue_protection_donnees, user: user)) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+
+      context "when user is the responsable traitement associated to this enrollment" do
+        let(:original_enrollment) { create(:enrollment, :franceconnect, responsable_traitement: build(:team_member, :responsable_traitement, user: user)) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+
+      context "when user is a reporter for the enrollment target api" do
+        let(:user) { create(:user, roles: ["api_particulier:reporter"]) }
+        let(:original_enrollment) { create(:enrollment, :api_particulier) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+
+      context "when user is a reporter for the enrollment group" do
+        let(:user) { create(:user, roles: ["api_particulier:cnaf:reporter"]) }
+        let(:original_enrollment) { create(:enrollment, :api_particulier) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+
+      context "when user is a only reporter for another group" do
+        let(:user) { create(:user, roles: ["api_entreprise:pole_emploi:reporter"]) }
+        let(:original_enrollment) { create(:enrollment, :api_particulier) }
+
+        it { is_expected.to have_http_status(:forbidden) }
+      end
+
+      context "when user is a only reporter for another target api" do
+        let(:user) { create(:user, roles: ["api_entreprise:reporter"]) }
+        let(:original_enrollment) { create(:enrollment, :api_particulier) }
+
+        it { is_expected.to have_http_status(:forbidden) }
+      end
+    end
+  end
+
+  describe "payload" do
+    subject(:show_enrollment_payload) do
+      get :show, params: {
+        enrollment_id: enrollment.id,
+        id: snapshot.id
+      }
+
+      JSON.parse(response.body)
+    end
+
+    let(:enrollment) do
+      original_enrollment.snapshot!
+      original_enrollment.update!(intitule: "new intitule")
+      original_enrollment.team_members.first.update!(given_name: "new given name")
+      original_enrollment
+    end
+
+    let(:snapshot) { enrollment.last_snapshot }
+    let(:original_enrollment) { create(:enrollment, :franceconnect, user: user) }
+    let(:user) { create(:user) }
+
+    before do
+      login(user)
+    end
+
+    it "renders the snapshot version" do
+      expect(show_enrollment_payload["intitule"]).not_to eq("new intitule")
+      expect(show_enrollment_payload["team_members"][0]["given_name"]).not_to eq("new given name")
+    end
+  end
+end

--- a/backend/spec/factories/enrollments.rb
+++ b/backend/spec/factories/enrollments.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
   factory :enrollment do
     status { "draft" }
     intitule { "Intitulé" }
+    siret { "12345678901234" }
 
     trait :draft
 

--- a/backend/spec/factories/enrollments.rb
+++ b/backend/spec/factories/enrollments.rb
@@ -148,6 +148,7 @@ FactoryBot.define do
 
     trait :validated do
       status { "validated" }
+      last_validated_at { DateTime.now }
 
       with_delegue_protection_donnees
       with_responsable_traitement

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe Enrollment, type: :model do
 
   describe "state_machine" do
     let(:states) { [:draft, :submitted, :changes_requested, :validated, :refused, :revoked, :archived] }
+    let(:enrollment_validated) { create(:enrollment, :franceconnect, status: "validated") }
 
     it "has valid states in state_machine" do
       expect(Enrollment.state_machine.states.map(&:name)).to eq(states)
+    end
+
+    it "cannot transition from submitted to archived" do
+      expect(enrollment_validated.can_archive_status?).to be_falsey
     end
   end
 

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Enrollment, type: :model do
     end
 
     context "when enrollment has been previously validated and in draft mode" do
-      let(:enrollment) { create(:enrollment, :franceconnect, :validated) }
+      let(:enrollment) { create(:enrollment, :api_entreprise, :validated) }
 
       before do
         ReopenEnrollment.call(enrollment:, user: enrollment.demandeurs.first.user)

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Enrollment, type: :model do
     let(:enrollment) { create(:enrollment, target_api, :submitted) }
     let(:params) { {user_id: user.id, comment: "whatever"} }
 
+    describe "snapshotting" do
+      let(:target_api) { :api_entreprise }
+
+      it "updates last_validated_at" do
+        expect {
+          subject
+        }.to change { enrollment.reload.last_validated_at }
+      end
+
+      it "creates a snapshot of this model " do
+        expect {
+          subject
+        }.to change { enrollment.reload.snapshots.count }.by(1)
+      end
+    end
+
     context "with aidants_connect as target api" do
       let(:target_api) { :aidants_connect }
 

--- a/backend/spec/models/enrollment_spec.rb
+++ b/backend/spec/models/enrollment_spec.rb
@@ -55,6 +55,37 @@ RSpec.describe Enrollment, type: :model do
     end
   end
 
+  describe "archive transition" do
+    subject { enrollment.archive_status }
+
+    context "when it is in draft" do
+      let(:enrollment) { create(:enrollment, :franceconnect, :draft) }
+
+      it { is_expected.to be_truthy }
+      it "changes status to archived" do
+        subject
+
+        expect(enrollment.reload.status).to eq("archived")
+      end
+    end
+
+    context "when enrollment has been previously validated and in draft mode" do
+      let(:enrollment) { create(:enrollment, :franceconnect, :validated) }
+
+      before do
+        ReopenEnrollment.call(enrollment:, user: enrollment.demandeurs.first.user)
+      end
+
+      it { is_expected.to be_falsy }
+
+      it "does not change status to archived" do
+        subject
+
+        expect(enrollment.reload.status).to eq("draft")
+      end
+    end
+  end
+
   describe "validate transition" do
     subject { enrollment.validate_status(params) }
 

--- a/backend/spec/models/enrollment_versioning_spec.rb
+++ b/backend/spec/models/enrollment_versioning_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Enrollment, "versionning", type: :model do
+  describe "reify to one previous version" do
+    subject(:reify) { enrollment.last_snapshot.fetch_reified_items }
+
+    let(:enrollment) do
+      enrollment = create(:enrollment, :api_particulier, :submitted)
+
+      enrollment.snapshot!
+
+      enrollment.update!(intitule: "new intitule")
+      enrollment.team_members.first.update!(given_name: "new demandeur given name")
+
+      enrollment
+    end
+
+    it "reverts to the previous version the model and associations" do
+      expect(reify[0].intitule).not_to eq("new intitule")
+      expect(reify[1]["team_members"].first.given_name).not_to eq("new demandeur given name")
+    end
+  end
+end

--- a/backend/spec/organizers/reopen_enrollment_spec.rb
+++ b/backend/spec/organizers/reopen_enrollment_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe ReopenEnrollment, type: :organizer do
+  subject(:reopen_enrollment) { described_class.call(enrollment: enrollment, user: user) }
+
+  let(:user) { create(:user) }
+  let(:enrollment) { create(:enrollment, :api_particulier, enrollment_status) }
+
+  context "when enrollment is validated" do
+    let(:enrollment_status) { :validated }
+
+    it { is_expected.to be_success }
+
+    it "changes enrollment status to pending" do
+      expect {
+        reopen_enrollment
+      }.to change { enrollment.reload.status }.from("validated").to("draft")
+    end
+
+    it "creates a new event" do
+      expect {
+        reopen_enrollment
+      }.to change(Event, :count).by(1)
+
+      expect(enrollment.reload.events.last.name).to eq("reopen")
+    end
+  end
+
+  context "when enrollment is not validated" do
+    let(:enrollment_status) { :submitted }
+
+    it { is_expected.to be_a_failure }
+
+    it "sets errors" do
+      expect(reopen_enrollment.errors).to be_present
+    end
+  end
+end

--- a/backend/test/fixtures/team_members.yml
+++ b/backend/test/fixtures/team_members.yml
@@ -9,7 +9,7 @@ DEMANDEUR: &DEMANDEUR
   family_name: Demandeur
   type: demandeur
   job: Demandeur
-  phone_number: 0103821213
+  phone_number: 0603821213
   user_id: <%= ActiveRecord::FixtureSet.identify(:user) %>
 
 ALTERNATIVE_DEMANDEUR: &ALTERNATIVE_DEMANDEUR
@@ -18,7 +18,7 @@ ALTERNATIVE_DEMANDEUR: &ALTERNATIVE_DEMANDEUR
   family_name: Demandeur Alternatif
   type: demandeur
   job: Demandeur
-  phone_number: 0103821215
+  phone_number: 0603821215
   user_id: <%= ActiveRecord::FixtureSet.identify(:alternative_demandeur) %>
 
 RESPONSABLE_TRAITEMENT: &RESPONSABLE_TRAITEMENT
@@ -27,7 +27,7 @@ RESPONSABLE_TRAITEMENT: &RESPONSABLE_TRAITEMENT
   family_name: Responsable Traitement
   type: responsable_traitement
   job: Responsable Traitement
-  phone_number: 0103821214
+  phone_number: 0603821214
   user_id: <%= ActiveRecord::FixtureSet.identify(:responsable_traitement) %>
 
 DELEGUE_PROTECTION_DONNEES: &DELEGUE_PROTECTION_DONNEES
@@ -36,7 +36,7 @@ DELEGUE_PROTECTION_DONNEES: &DELEGUE_PROTECTION_DONNEES
   family_name: Délégué à la protection des données
   type: delegue_protection_donnees
   job: Délégué à la protection des données
-  phone_number: 0103821215
+  phone_number: 0603821215
   user_id: <%= ActiveRecord::FixtureSet.identify(:delegue_protection_donnees) %>
 
 RESPONSABLE_TECHNIQUE: &RESPONSABLE_TECHNIQUE
@@ -45,7 +45,7 @@ RESPONSABLE_TECHNIQUE: &RESPONSABLE_TECHNIQUE
   family_name: Responsable Technique
   type: responsable_technique
   job: Responsable Technique
-  phone_number: 0103821216
+  phone_number: 0603821216
   user_id: <%= ActiveRecord::FixtureSet.identify(:responsable_technique) %>
 
 CONTACT_METIER: &CONTACT_METIER
@@ -54,7 +54,7 @@ CONTACT_METIER: &CONTACT_METIER
   family_name: Contact Métier
   type: contact_metier
   job: Contact Métier
-  phone_number: 0103821217
+  phone_number: 0603821217
   user_id: <%= ActiveRecord::FixtureSet.identify(:contact_metier) %>
 
 # 📝 DRAFT ENROLLMENTS TEAM MEMBERS

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -1,6 +1,10 @@
 # keep these email addresses synchronised with the corresponding addresses in moncomptepro/scripts/fixtures.sql
 user:
   email: user@yopmail.com
+  phone_number: 0603821215
+  organizations:
+    - id: 211
+      siret: "83906810300010"
 
 alternative_demandeur:
   email: demandeuralternatif@yopmail.com

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "test": "CI=true craco test",
     "eject": "react-scripts eject",
     "precommit": "pretty-quick --staged",
-    "lint": "eslint src/**/*.{js,ts,tsx} --max-warnings=0",
+    "lint": "eslint src/**/*.{js,ts,tsx} --max-warnings=0 --fix",
     "start": "serve -s build"
   },
   "keywords": [],

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -55,6 +55,14 @@ footer {
   margin: 1.5rem auto 1.5rem;
 }
 
+.highlighted {
+  padding: 10px;
+  box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1),
+    0 8px 10px -6px rgb(0 0 0 / 0.1);
+  border-radius: 5px;
+  background-color: #f5f5ff !important;
+}
+
 @media all and (max-width: 1248px) {
   .page-container {
     margin: 1.5rem;

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -20,6 +20,7 @@ import PublicEnrollmentList from './components/templates/PublicEnrollmentList';
 import Stats from './components/templates/Stats';
 import UserEnrollmentList from './components/templates/UserEnrollmentList';
 import InstructorHome from './components/templates/InstructorHome';
+import ReopenEnrollment from './components/templates/ReopenEnrollment';
 
 export const Routes = () => {
   const { user } = useAuth();
@@ -51,6 +52,11 @@ export const Routes = () => {
       <Route
         path="copy-authorization-request/:enrollmentId"
         element={<AuthRequired children={<CopyEnrollment />} />}
+      />
+
+      <Route
+        path="reopen-enrollment-request/:enrollmentId"
+        element={<AuthRequired children={<ReopenEnrollment />} />}
       />
 
       <Route

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -101,7 +101,16 @@ export const Routes = () => {
               <FormRouter />
             </AuthRequired>
           }
-        />
+        >
+          <Route
+            path=":snapshotId"
+            element={
+              <AuthRequired>
+                <FormRouter />
+              </AuthRequired>
+            }
+          />
+        </Route>
       </Route>
     </ReactRouterRoutes>
   );

--- a/frontend/src/components/atoms/EventButton.tsx
+++ b/frontend/src/components/atoms/EventButton.tsx
@@ -1,6 +1,7 @@
-import React, { MouseEventHandler } from 'react';
+import React, { MouseEventHandler, useContext } from 'react';
 import { EventConfiguration } from '../../config/event-configuration';
 import Button from './hyperTexts/Button';
+import { FormContext } from '../templates/Form';
 
 type Props = EventConfiguration['displayProps'] & {
   disabled?: boolean;
@@ -11,24 +12,31 @@ type Props = EventConfiguration['displayProps'] & {
 
 const EventButton: React.FC<Props> = ({
   label,
+  getLabel = undefined,
   icon,
   disabled,
   onClick,
   secondary = false,
   quaternary = false,
   iconFill = false,
-}) => (
-  // @ts-ignore
-  <Button
-    icon={icon}
-    iconFill={iconFill}
-    secondary={secondary}
-    quaternary={quaternary}
-    onClick={onClick}
-    disabled={disabled}
-  >
-    {label}
-  </Button>
-);
+}) => {
+  const { enrollment } = useContext(FormContext)!;
+
+  return (
+    // @ts-ignore
+    <Button
+      icon={icon}
+      iconFill={iconFill}
+      secondary={secondary}
+      quaternary={quaternary}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {getLabel !== undefined && enrollment !== undefined
+        ? getLabel(enrollment)
+        : label}
+    </Button>
+  );
+};
 
 export default EventButton;

--- a/frontend/src/components/atoms/icons/fr-fi-icons.tsx
+++ b/frontend/src/components/atoms/icons/fr-fi-icons.tsx
@@ -221,6 +221,21 @@ export const ArrowRightIcon: React.FC<IconProps> = ({
   />
 );
 
+export const ArrowWithTailRightIcon: React.FC<IconProps> = ({
+  color,
+  large,
+  small,
+  title,
+}) => (
+  <FrFiIcon
+    type="arrow-right-line"
+    color={color}
+    large={large}
+    small={small}
+    title={title}
+  />
+);
+
 export const CheckCircleIcon: React.FC<IconProps> = ({
   color,
   large,

--- a/frontend/src/components/atoms/inputs/TextAreaInput.tsx
+++ b/frontend/src/components/atoms/inputs/TextAreaInput.tsx
@@ -8,6 +8,7 @@ interface TextAreaInputProps
   helper?: string;
   meta?: string;
   ariaLabel?: string;
+  highlighted?: boolean;
 }
 
 export const TextAreaInput: React.FC<TextAreaInputProps> = ({
@@ -17,6 +18,7 @@ export const TextAreaInput: React.FC<TextAreaInputProps> = ({
   name,
   placeholder = '',
   value = undefined,
+  highlighted = false,
   disabled,
   onChange,
   ariaLabel,
@@ -27,8 +29,14 @@ export const TextAreaInput: React.FC<TextAreaInputProps> = ({
   // we generate a unique id prefixed by the field name
   const [id] = useState(uniqueId(name));
 
+  let classNames = 'fr-input-group';
+
+  if (highlighted) {
+    classNames += ' highlighted';
+  }
+
   return (
-    <div className="fr-input-group">
+    <div className={classNames}>
       <Label
         id={id}
         label={label}

--- a/frontend/src/components/molecules/Card/style.css
+++ b/frontend/src/components/molecules/Card/style.css
@@ -26,9 +26,7 @@
 }
 
 .datapass_card {
-  filter: drop-shadow(0 4px 3px rgb(0 0 0 / 0.07))
-    drop-shadow(0 2px 2px rgb(0 0 0 / 0.06));
-  border-radius: 5px;
+  border: 1px solid #dddddd;
   padding: 1.5em;
   background-color: white;
 }

--- a/frontend/src/components/molecules/EnrollmentCard/index.tsx
+++ b/frontend/src/components/molecules/EnrollmentCard/index.tsx
@@ -57,7 +57,9 @@ export const EnrollmentCard: React.FC<Props> = ({
   };
 
   const canReopen = () => {
-    return enrollment.can_reopen || false;
+    return (
+      enrollment.can_reopen && enrollment.status === EnrollmentStatus.validated
+    );
   };
 
   const adjustTextToDesiredLength = (

--- a/frontend/src/components/molecules/EnrollmentCard/index.tsx
+++ b/frontend/src/components/molecules/EnrollmentCard/index.tsx
@@ -8,8 +8,7 @@ import { EnrollmentStatus } from '../../../config/status-parameters';
 import { reopenEnrollment } from '../../../services/enrollments';
 
 import './style.css';
-import { isReopenned } from '../../../lib';
-import { EnrollmentEvent } from '../../../config/event-configuration';
+import { getLastSnapshotId, isReopenned } from '../../../lib';
 import moment from 'moment';
 import { ArrowWithTailRightIcon } from '../../atoms/icons/fr-fi-icons';
 
@@ -32,9 +31,7 @@ export const EnrollmentCard: React.FC<Props> = ({
   const { label, icon } = useDataProvider(enrollment.target_api);
 
   const isEnrollmentReopenned = isReopenned(enrollment);
-  const lastSnapshotId = enrollment.events?.find(
-    ({ name }) => name === EnrollmentEvent.validate
-  )?.entity_id;
+  const lastSnapshotId = getLastSnapshotId(enrollment.events!);
 
   let className = 'enrollment-card';
 

--- a/frontend/src/components/molecules/EnrollmentCard/index.tsx
+++ b/frontend/src/components/molecules/EnrollmentCard/index.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback } from 'react';
-import './style.css';
 import Card from '../Card';
 import Badge, { StatusBadge } from '../StatusBadge';
 import { Enrollment } from '../../../config';
 import { useDataProvider } from '../../templates/hooks/use-data-provider';
 import Button from '../../atoms/hyperTexts/Button';
+import { EnrollmentStatus } from '../../../config/status-parameters';
+import { reopenEnrollment } from '../../../services/enrollments';
+import useListItemNavigation from '../../templates/hooks/use-list-item-navigation';
 
 import './style.css';
 
@@ -23,6 +25,7 @@ export const EnrollmentCard: React.FC<Props> = ({
   onSelect,
   cardSize,
 }) => {
+  const { goToItem } = useListItemNavigation();
   const { label, icon } = useDataProvider(enrollment.target_api);
 
   const handleClick = useCallback(
@@ -37,6 +40,11 @@ export const EnrollmentCard: React.FC<Props> = ({
   if (cardSize === 'large') {
     className += ' large';
   }
+
+  const onReopenClick = async (event: React.MouseEvent) => {
+    const reopenedEnrollment = await reopenEnrollment({ id: enrollment.id });
+    goToItem(reopenedEnrollment.target_api, reopenedEnrollment.id, event);
+  };
 
   const adjustTextToDesiredLength = (
     text: string | undefined,
@@ -76,7 +84,14 @@ export const EnrollmentCard: React.FC<Props> = ({
           >
             {adjustTextToDesiredLength(enrollment.description, 120)}
           </p>
-          <Button onClick={handleClick}>Continuer</Button>
+          <div className="enrollment-card-actions">
+            <Button onClick={handleClick}>Continuer</Button>
+            {enrollment.status === EnrollmentStatus.validated && (
+              <Button secondary onClick={onReopenClick}>
+                Mettre à jour
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </Card>

--- a/frontend/src/components/molecules/EnrollmentCard/index.tsx
+++ b/frontend/src/components/molecules/EnrollmentCard/index.tsx
@@ -8,7 +8,7 @@ import { EnrollmentStatus } from '../../../config/status-parameters';
 import { reopenEnrollment } from '../../../services/enrollments';
 
 import './style.css';
-import { getLastSnapshotId, isReopenned } from '../../../lib';
+import { getLastSnapshotId } from '../../../lib';
 import moment from 'moment';
 import { ArrowWithTailRightIcon } from '../../atoms/icons/fr-fi-icons';
 
@@ -30,7 +30,6 @@ export const EnrollmentCard: React.FC<Props> = ({
 }) => {
   const { label, icon } = useDataProvider(enrollment.target_api);
 
-  const isEnrollmentReopenned = isReopenned(enrollment);
   const lastSnapshotId = getLastSnapshotId(enrollment.events!);
 
   let className = 'enrollment-card';
@@ -79,7 +78,7 @@ export const EnrollmentCard: React.FC<Props> = ({
           <Badge>n°{enrollment.id}</Badge>
           <StatusBadge
             status={
-              isEnrollmentReopenned
+              enrollment.reopening
                 ? EnrollmentStatus.validated
                 : enrollment.status
             }
@@ -109,7 +108,7 @@ export const EnrollmentCard: React.FC<Props> = ({
                     enrollment.target_api,
                     enrollment.id,
                     e,
-                    lastSnapshotId
+                    enrollment.reopening ? lastSnapshotId : undefined
                   );
                 }}
               >
@@ -124,7 +123,7 @@ export const EnrollmentCard: React.FC<Props> = ({
           </div>
         </div>
       </Card>
-      {isReopenned(enrollment) && (
+      {enrollment.reopening && (
         <div className="enrollment-card-footer">
           <div className="enrollment-card-footer-details">
             <div className="enrollment-card-footer-details-title">

--- a/frontend/src/components/molecules/EnrollmentCard/index.tsx
+++ b/frontend/src/components/molecules/EnrollmentCard/index.tsx
@@ -56,6 +56,10 @@ export const EnrollmentCard: React.FC<Props> = ({
     return lastReopenEvent?.created_at;
   };
 
+  const canReopen = () => {
+    return enrollment.can_reopen || false;
+  };
+
   const adjustTextToDesiredLength = (
     text: string | undefined,
     length: number
@@ -114,7 +118,7 @@ export const EnrollmentCard: React.FC<Props> = ({
               >
                 Consulter
               </Button>
-              {enrollment.status === EnrollmentStatus.validated && (
+              {canReopen() && (
                 <Button secondary onClick={onReopenClick}>
                   Mettre à jour
                 </Button>

--- a/frontend/src/components/molecules/EnrollmentCard/style.css
+++ b/frontend/src/components/molecules/EnrollmentCard/style.css
@@ -1,7 +1,6 @@
 .enrollment-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
   flex: none !important;
   width: 30%;
 }
@@ -64,7 +63,41 @@
 }
 
 .enrollment-card-footer {
-  background-color: aquamarine;
+  border-left: 1px solid #dddddd;
+  border-right: 1px solid #dddddd;
+  border-bottom: 5px solid #000091;
+  background-color: #f6f6f6;
+  padding: 20px 15px;
+  display: flex;
+}
+
+.enrollment-card-footer-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.enrollment-card-footer-details-title {
+  font-weight: 600;
+  color: var(--text-action-high-blue-france);
+}
+
+.enrollment-card-footer-details-button {
+  padding: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 3px;
+  color: #666666;
+}
+
+.enrollment-card-footer-status {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 @media all and (max-width: 992px) {

--- a/frontend/src/components/molecules/EnrollmentCard/style.css
+++ b/frontend/src/components/molecules/EnrollmentCard/style.css
@@ -63,6 +63,10 @@
   gap: 15px;
 }
 
+.enrollment-card-footer {
+  background-color: aquamarine;
+}
+
 @media all and (max-width: 992px) {
   .enrollment-card {
     width: 45%;

--- a/frontend/src/components/molecules/EnrollmentCard/style.css
+++ b/frontend/src/components/molecules/EnrollmentCard/style.css
@@ -58,6 +58,11 @@
   margin-bottom: 0.5rem;
 }
 
+.enrollment-card-actions {
+  display: flex;
+  gap: 15px;
+}
+
 @media all and (max-width: 992px) {
   .enrollment-card {
     width: 45%;

--- a/frontend/src/components/molecules/StateBadge/index.tsx
+++ b/frontend/src/components/molecules/StateBadge/index.tsx
@@ -1,5 +1,4 @@
 import { Enrollment } from '../../../config';
-import { isReopenned } from '../../../lib';
 import Badge, { BadgeType } from '../../atoms/hyperTexts/Badge';
 import { RecycleIcon } from '../../atoms/icons/fr-fi-icons';
 
@@ -8,7 +7,7 @@ type Props = {
 };
 
 const StateBadge: React.FC<Props> = ({ enrollment }) => {
-  if (isReopenned(enrollment)) {
+  if (enrollment.reopening) {
     return (
       <Badge type={BadgeType.purple} small={true}>
         Mise à jour

--- a/frontend/src/components/molecules/StateBadge/index.tsx
+++ b/frontend/src/components/molecules/StateBadge/index.tsx
@@ -1,5 +1,4 @@
 import { Enrollment } from '../../../config';
-import { EnrollmentStatus } from '../../../config/status-parameters';
 import { isReopenned } from '../../../lib';
 import Badge, { BadgeType } from '../../atoms/hyperTexts/Badge';
 import { RecycleIcon } from '../../atoms/icons/fr-fi-icons';
@@ -9,13 +8,10 @@ type Props = {
 };
 
 const StateBadge: React.FC<Props> = ({ enrollment }) => {
-  if (
-    isReopenned(enrollment) &&
-    enrollment.status !== EnrollmentStatus.validated
-  ) {
+  if (isReopenned(enrollment)) {
     return (
       <Badge type={BadgeType.purple} small={true}>
-        Demande de mise à jour
+        Mise à jour
       </Badge>
     );
   }

--- a/frontend/src/components/molecules/StateBadge/index.tsx
+++ b/frontend/src/components/molecules/StateBadge/index.tsx
@@ -1,4 +1,6 @@
 import { Enrollment } from '../../../config';
+import { EnrollmentStatus } from '../../../config/status-parameters';
+import { isReopenned } from '../../../lib';
 import Badge, { BadgeType } from '../../atoms/hyperTexts/Badge';
 import { RecycleIcon } from '../../atoms/icons/fr-fi-icons';
 
@@ -7,6 +9,17 @@ type Props = {
 };
 
 const StateBadge: React.FC<Props> = ({ enrollment }) => {
+  if (
+    isReopenned(enrollment) &&
+    enrollment.status !== EnrollmentStatus.validated
+  ) {
+    return (
+      <Badge type={BadgeType.purple} small={true}>
+        Demande de mise à jour
+      </Badge>
+    );
+  }
+
   if (enrollment.requested_changes_have_been_done) {
     return (
       <p className="fr-badge fr-badge--sm fr-badge--blue-cumulus">

--- a/frontend/src/components/organisms/form-sections/DescriptionSection.tsx
+++ b/frontend/src/components/organisms/form-sections/DescriptionSection.tsx
@@ -22,6 +22,10 @@ const DescriptionSection = () => {
       documents_attributes = [],
     },
   } = useContext(FormContext)!;
+  const queryParams = new URLSearchParams(window.location.search);
+  const { highlightedSections = '' } = Object.fromEntries(
+    queryParams.entries()
+  );
 
   return (
     <ScrollablePanel scrollableId={SECTION_ID}>
@@ -37,6 +41,7 @@ const DescriptionSection = () => {
         required
       />
       <TextAreaInput
+        highlighted={highlightedSections.split(',').includes('description')}
         label="Description du projet (à quoi va-t-il servir ? qui l’utilisera ?)"
         name="description"
         value={description}

--- a/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/ActivityFeed.tsx
@@ -93,6 +93,10 @@ const eventToDisplayableContent = {
     icon: <InfoFillIcon color={'var(--text-default-warning)'} />,
     label: 'a répondu à un avis',
   },
+  [EnrollmentEvent.reopen]: {
+    icon: <InfoFillIcon color={'var(--text-default-info)'} />,
+    label: 'a réouvert l’habilitation',
+  },
 };
 
 export const EventItem: React.FC<Event> = ({

--- a/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
@@ -11,7 +11,6 @@ import './index.css';
 import NotificationSubSection from './NotificationSubSection';
 import { Event } from '../../../../config';
 import Alert from '../../../atoms/Alert';
-import { isReopenned } from '../../../../lib';
 import useListItemNavigation from '../../../templates/hooks/use-list-item-navigation';
 import { EnrollmentStatus } from '../../../../config/status-parameters';
 import { useParams } from 'react-router-dom';
@@ -23,13 +22,11 @@ export const HeadSection = () => {
   const { goToItem } = useListItemNavigation();
   const { label } = useDataProvider(enrollment.target_api);
 
-  const isEnrollmentReopenned = isReopenned(enrollment);
-
   return (
     <ScrollablePanel scrollableId="head">
       <div className="badge-sub-section fr-mb-3w">
         <>
-          {isEnrollmentReopenned && !snapshotId
+          {enrollment.reopening && !snapshotId
             ? 'Mise à jour des informations'
             : 'Vous demandez l’accès à'}
         </>
@@ -38,7 +35,7 @@ export const HeadSection = () => {
           {enrollment.id && (
             <Badge type={BadgeType.info}>Habilitation n°{enrollment.id}</Badge>
           )}
-          {isEnrollmentReopenned && (
+          {enrollment.reopening && (
             <Badge type={BadgeType.purple}>Demande de mise à jour</Badge>
           )}
           <StatusBadge status={enrollment.status} />
@@ -51,7 +48,7 @@ export const HeadSection = () => {
           )}
         </div>
       </div>
-      {isEnrollmentReopenned && enrollment.status === EnrollmentStatus.draft && (
+      {enrollment.reopening && enrollment.status === EnrollmentStatus.draft && (
         <div className="fr-py-5w">
           <Alert title="Pas de panique">
             <p>

--- a/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
@@ -50,11 +50,13 @@ export const HeadSection = () => {
       </div>
       {enrollment.reopening && enrollment.status === EnrollmentStatus.draft && (
         <div className="fr-py-5w">
-          <Alert title="Pas de panique">
+          <Alert title="Mettez à jour votre habilitation sereinement">
             <p>
-              Ne vous inquiétez pas, vos demandes de modifications n’auront pas
-              d’impact sur votre habilitation initialement validée. Nous
-              mettrons à jour vos informations et conserverons les anciennes.
+              Votre demande de mise à jour n’aura pas d’impact sur votre
+              habilitation initialement validée. Nous mettrons à jour vos
+              informations et conserverons les anciennes. De plus, dans le cas
+              où cette demande de mise à jour est refusée, votre habilitation
+              initiale reste bien évidemment valide !
             </p>
           </Alert>
         </div>

--- a/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
@@ -29,9 +29,7 @@ export const HeadSection = () => {
     <ScrollablePanel scrollableId="head">
       <div className="badge-sub-section fr-mb-3w">
         <>
-          {isEnrollmentReopenned &&
-          !snapshotId &&
-          enrollment.status !== EnrollmentStatus.validated
+          {isEnrollmentReopenned && !snapshotId
             ? 'Mise à jour des informations'
             : 'Vous demandez l’accès à'}
         </>

--- a/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
@@ -40,6 +40,9 @@ export const HeadSection = () => {
           {enrollment.id && (
             <Badge type={BadgeType.info}>Habilitation n°{enrollment.id}</Badge>
           )}
+          {isEnrollmentReopenned && (
+            <Badge type={BadgeType.purple}>Demande de mise à jour</Badge>
+          )}
           <StatusBadge status={enrollment.status} />
           {enrollment.copied_from_enrollment_id && (
             <Link

--- a/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/HeadSection/index.tsx
@@ -10,31 +10,79 @@ import ActivityFeed from './ActivityFeed';
 import './index.css';
 import NotificationSubSection from './NotificationSubSection';
 import { Event } from '../../../../config';
+import Alert from '../../../atoms/Alert';
+import { isReopenned } from '../../../../lib';
+import useListItemNavigation from '../../../templates/hooks/use-list-item-navigation';
+import { EnrollmentStatus } from '../../../../config/status-parameters';
+import { useParams } from 'react-router-dom';
 
 export const HeadSection = () => {
-  const {
-    enrollment: { id, target_api, status, copied_from_enrollment_id, events },
-  } = useContext(FormContext)!;
+  const { snapshotId } = useParams();
+  const { enrollment } = useContext(FormContext)!;
 
-  const { label } = useDataProvider(target_api);
+  const { goToItem } = useListItemNavigation();
+  const { label } = useDataProvider(enrollment.target_api);
+
+  const isEnrollmentReopenned = isReopenned(enrollment);
 
   return (
     <ScrollablePanel scrollableId="head">
       <div className="badge-sub-section fr-mb-3w">
-        <>Vous demandez l’accès à</>
+        <>
+          {isEnrollmentReopenned &&
+          !snapshotId &&
+          enrollment.status !== EnrollmentStatus.validated
+            ? 'Mise à jour des informations'
+            : 'Vous demandez l’accès à'}
+        </>
         <h1>{label}</h1>
         <div className="datapass-badge-group">
-          {id && <Badge type={BadgeType.info}>Habilitation n°{id}</Badge>}
-          <StatusBadge status={status} />
-          {copied_from_enrollment_id && (
-            <Link href={`/authorization-request/${copied_from_enrollment_id}`}>
-              <span>Copie de n°{copied_from_enrollment_id}</span>
+          {enrollment.id && (
+            <Badge type={BadgeType.info}>Habilitation n°{enrollment.id}</Badge>
+          )}
+          <StatusBadge status={enrollment.status} />
+          {enrollment.copied_from_enrollment_id && (
+            <Link
+              href={`/authorization-request/${enrollment.copied_from_enrollment_id}`}
+            >
+              <span>Copie de n°{enrollment.copied_from_enrollment_id}</span>
             </Link>
           )}
         </div>
       </div>
+      {isEnrollmentReopenned && enrollment.status === EnrollmentStatus.draft && (
+        <div className="fr-py-5w">
+          <Alert title="Pas de panique">
+            <p>
+              Ne vous inquiétez pas, vos demandes de modifications n’auront pas
+              d’impact sur votre habilitation initialement validée. Nous
+              mettrons à jour vos informations et conserverons les anciennes.
+            </p>
+          </Alert>
+        </div>
+      )}
+      {snapshotId && (
+        <div className="fr-py-5w">
+          <Alert title="Mise à jour de vos informations">
+            <p>
+              Vous avez demandé à mettre à jour certaines informations pour
+              cette habilitation.
+            </p>
+            <Link
+              inline
+              onClick={(e: React.MouseEvent<HTMLElement>) => {
+                goToItem(enrollment.target_api, enrollment.id, e);
+              }}
+            >
+              Voir les informations modifiées
+            </Link>
+          </Alert>
+        </div>
+      )}
       <div className="feed-sub-section fr-py-3w">
-        {!isEmpty(events) && <ActivityFeed events={events as Event[]} />}
+        {!isEmpty(enrollment.events) && (
+          <ActivityFeed events={enrollment.events as Event[]} />
+        )}
       </div>
       <div className="fr-pt-3w">
         <NotificationSubSection />

--- a/frontend/src/components/organisms/form-sections/ÉquipeSection/Contact.tsx
+++ b/frontend/src/components/organisms/form-sections/ÉquipeSection/Contact.tsx
@@ -31,6 +31,7 @@ interface ContactProps extends TeamMember {
   canUpdatePersonalInformation: boolean;
   heading: string;
   index: number;
+  highlighted?: boolean;
 }
 
 export const Contact: React.FC<ContactProps> = ({
@@ -47,6 +48,7 @@ export const Contact: React.FC<ContactProps> = ({
   displayMobilePhoneLabel = false,
   contactByEmailOnly = false,
   displayIdForAdministrator = false,
+  highlighted = false,
   disabled,
   onChange,
   onDelete,
@@ -54,7 +56,7 @@ export const Contact: React.FC<ContactProps> = ({
   canUpdatePersonalInformation = false,
   type = '',
 }) => (
-  <Card>
+  <Card className={highlighted ? 'highlighted' : ''}>
     <CardHead>
       <h3>
         {heading}

--- a/frontend/src/components/organisms/form-sections/ÉquipeSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/ÉquipeSection/index.tsx
@@ -131,6 +131,11 @@ const ÉquipeSection = ({
       .value();
   }, [initialContacts, responsableTechniqueNeedsMobilePhone]);
 
+  const queryParams = new URLSearchParams(window.location.search);
+  const { highlightedSections = '' } = Object.fromEntries(
+    queryParams.entries()
+  );
+
   const newTeamMembers = useNewTeamMembers({
     user: user as User,
     team_members,
@@ -275,6 +280,9 @@ const ÉquipeSection = ({
                 .filter(({ type: t }) => t === type)
                 .map(({ id, tmp_id, ...team_member }) => (
                   <Contact
+                    highlighted={highlightedSections
+                      .split(',')
+                      .includes(team_member.type!)}
                     type={team_member.type}
                     heading={header!}
                     key={id || tmp_id}

--- a/frontend/src/components/templates/Form/index.tsx
+++ b/frontend/src/components/templates/Form/index.tsx
@@ -10,7 +10,10 @@ import React, {
 } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getStateFromUrlParams } from '../../../lib';
-import { getUserEnrollment } from '../../../services/enrollments';
+import {
+  getUserEnrollment,
+  getUserEnrollmentSnapshot,
+} from '../../../services/enrollments';
 import Alert, { AlertType } from '../../atoms/Alert';
 import WarningEmoji from '../../atoms/icons/WarningEmoji';
 import { Linkify } from '../../molecules/Linkify';
@@ -73,7 +76,7 @@ export const Form: React.FC<FormProps> = ({
   const [errorMessages, setErrorMessages] = useState([]);
   const [successMessages, setSuccessMessages] = useState([]);
   const [isUserEnrollmentLoading, setIsUserEnrollmentLoading] = useState(true);
-  const { enrollmentId } = useParams();
+  const { enrollmentId, snapshotId } = useParams();
   const [hasNotFoundError, setHasNotFoundError] = useState(false);
   const navigate = useNavigate();
   const { goBackToList } = useListItemNavigation();
@@ -121,7 +124,16 @@ export const Form: React.FC<FormProps> = ({
   useEffect(() => {
     async function fetchUserEnrollment() {
       try {
-        const userEnrollment = await getUserEnrollment(Number(enrollmentId));
+        let userEnrollment = null;
+
+        if (enrollmentId && !snapshotId) {
+          userEnrollment = await getUserEnrollment(Number(enrollmentId));
+        } else if (enrollmentId && snapshotId) {
+          userEnrollment = await getUserEnrollmentSnapshot({
+            enrollmentId: Number(enrollmentId),
+            snapshotId: Number(snapshotId),
+          });
+        }
         dispatchSetEnrollment(userEnrollment);
         setIsUserEnrollmentLoading(false);
       } catch (error) {
@@ -132,7 +144,7 @@ export const Form: React.FC<FormProps> = ({
       }
     }
 
-    if (enrollmentId) {
+    if (enrollmentId || snapshotId) {
       fetchUserEnrollment();
     } else {
       const { demarche } = getStateFromUrlParams({
@@ -153,7 +165,7 @@ export const Form: React.FC<FormProps> = ({
       }
       setIsUserEnrollmentLoading(false);
     }
-  }, [enrollmentId, goBackToList]);
+  }, [enrollmentId, snapshotId, goBackToList]);
 
   useEffect(() => {
     if (label) {

--- a/frontend/src/components/templates/Form/index.tsx
+++ b/frontend/src/components/templates/Form/index.tsx
@@ -271,7 +271,7 @@ export const Form: React.FC<FormProps> = ({
           </FormContext.Provider>
         </OpenMessagePromptContextProvider>
 
-        {demandeurPhoneNumberWarning && (
+        {demandeurPhoneNumberWarning && !snapshotId && (
           <ConfirmationModal
             handleCancel={() => setDemandeurPhoneNumberWarning(false)}
             handleConfirm={() =>

--- a/frontend/src/components/templates/InstructorEnrollmentList.tsx
+++ b/frontend/src/components/templates/InstructorEnrollmentList.tsx
@@ -52,6 +52,7 @@ const InstructorEnrollmentList: React.FC = () => {
         page: pagination.pageIndex,
         sortBy: sorted,
         filter: filtered,
+        detailed: true,
       }).then(({ enrollments, meta: { total_pages } }) => {
         setLoading(false);
         setEnrollments(enrollments);

--- a/frontend/src/components/templates/RedirectToTheRightDataProviderForm.tsx
+++ b/frontend/src/components/templates/RedirectToTheRightDataProviderForm.tsx
@@ -10,6 +10,7 @@ const RedirectToTheRightDataProviderForm = () => {
   const [fetchEnrollmentError, setFetchEnrollmentError] = useState(false);
   const [fetchEnrollmentNotFound, setFetchEnrollmentNotFound] = useState(false);
   const [targetApi, setTargetApi] = useState<string | null>(null);
+  const queryParameters = new URLSearchParams(window.location.search);
 
   const fetchEnrollment = async ({
     enrollmentId,
@@ -42,6 +43,7 @@ const RedirectToTheRightDataProviderForm = () => {
       <Navigate
         to={{
           pathname: `/${targetApi.replace(/_/g, '-')}/${enrollmentId}`,
+          search: queryParameters.toString(),
         }}
         replace
       />

--- a/frontend/src/components/templates/ReopenEnrollment.tsx
+++ b/frontend/src/components/templates/ReopenEnrollment.tsx
@@ -1,53 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { reopenEnrollment } from '../../services/enrollments';
-import { Navigate, useParams } from 'react-router-dom';
-import { getErrorMessages } from '../../lib';
-import Loader from '../atoms/Loader';
-import { Linkify } from '../molecules/Linkify';
-import Alert, { AlertType } from '../atoms/Alert';
+import { useParams } from 'react-router-dom';
+import RedirectToTheRightDataProviderForm from './RedirectToTheRightDataProviderForm';
 
 const ReopenEnrollment = () => {
   const { enrollmentId }: { enrollmentId?: string } = useParams();
-
-  const [errorMessage, setErrorMessage] = useState<{
-    title: string;
-    message: string;
-  } | null>(null);
-  const [reopennedEnrollmentId, setReopennedEnrollmentId] = useState(null);
-  const [reopennedTargetApi, setReopennedTargetApi] = useState<string | null>(
-    null
-  );
 
   const triggerReopenEnrollment = async ({
     enrollmentId,
   }: {
     enrollmentId: string;
   }) => {
-    try {
-      setErrorMessage(null);
-
-      const { id, target_api } = await reopenEnrollment({
-        id: Number(enrollmentId),
-      });
-
-      setReopennedEnrollmentId(id);
-      setReopennedTargetApi(target_api);
-    } catch (e: any) {
-      if (e.response?.data?.title && e.response?.data?.message) {
-        setErrorMessage(e.response.data);
-      } else if (getErrorMessages(e)[0]) {
-        setErrorMessage({
-          title: 'Erreur',
-          message: getErrorMessages(e)[0],
-        });
-      } else {
-        setErrorMessage({
-          title: 'Erreur',
-          message: 'Erreur inconnue lors de la copie de l’habilitation.',
-        });
-      }
-    }
+    await reopenEnrollment({
+      id: Number(enrollmentId),
+    });
   };
 
   useEffect(() => {
@@ -56,38 +23,7 @@ const ReopenEnrollment = () => {
     }
   }, [enrollmentId]);
 
-  if (reopennedEnrollmentId && reopennedTargetApi) {
-    const queryParams = window.location.search;
-
-    return (
-      <Navigate
-        to={`/${reopennedTargetApi.replace(
-          /_/g,
-          '-'
-        )}/${reopennedEnrollmentId}`}
-        state={{ source: 'reopen-enrollment-request', search: queryParams }}
-        replace
-      />
-    );
-  }
-
-  if (errorMessage) {
-    return (
-      <div className="full-page">
-        <Alert title={errorMessage.title} type={AlertType.warning}>
-          <Linkify
-            message={`${errorMessage.message} L’habilitation #${enrollmentId} n’a pas été réouverte.`}
-          />
-        </Alert>
-      </div>
-    );
-  }
-
-  return (
-    <div className="full-page">
-      <Loader />
-    </div>
-  );
+  return <RedirectToTheRightDataProviderForm />;
 };
 
 export default ReopenEnrollment;

--- a/frontend/src/components/templates/ReopenEnrollment.tsx
+++ b/frontend/src/components/templates/ReopenEnrollment.tsx
@@ -57,13 +57,15 @@ const ReopenEnrollment = () => {
   }, [enrollmentId]);
 
   if (reopennedEnrollmentId && reopennedTargetApi) {
+    const queryParams = window.location.search;
+
     return (
       <Navigate
         to={`/${reopennedTargetApi.replace(
           /_/g,
           '-'
         )}/${reopennedEnrollmentId}`}
-        state={{ source: 'reopen-enrollment-request' }}
+        state={{ source: 'reopen-enrollment-request', search: queryParams }}
         replace
       />
     );

--- a/frontend/src/components/templates/ReopenEnrollment.tsx
+++ b/frontend/src/components/templates/ReopenEnrollment.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from 'react';
+
+import { reopenEnrollment } from '../../services/enrollments';
+import { Navigate, useParams } from 'react-router-dom';
+import { getErrorMessages } from '../../lib';
+import Loader from '../atoms/Loader';
+import { Linkify } from '../molecules/Linkify';
+import Alert, { AlertType } from '../atoms/Alert';
+
+const ReopenEnrollment = () => {
+  const { enrollmentId }: { enrollmentId?: string } = useParams();
+
+  const [errorMessage, setErrorMessage] = useState<{
+    title: string;
+    message: string;
+  } | null>(null);
+  const [reopennedEnrollmentId, setReopennedEnrollmentId] = useState(null);
+  const [reopennedTargetApi, setReopennedTargetApi] = useState<string | null>(
+    null
+  );
+
+  const triggerReopenEnrollment = async ({
+    enrollmentId,
+  }: {
+    enrollmentId: string;
+  }) => {
+    try {
+      setErrorMessage(null);
+
+      const { id, target_api } = await reopenEnrollment({
+        id: Number(enrollmentId),
+      });
+
+      setReopennedEnrollmentId(id);
+      setReopennedTargetApi(target_api);
+    } catch (e: any) {
+      if (e.response?.data?.title && e.response?.data?.message) {
+        setErrorMessage(e.response.data);
+      } else if (getErrorMessages(e)[0]) {
+        setErrorMessage({
+          title: 'Erreur',
+          message: getErrorMessages(e)[0],
+        });
+      } else {
+        setErrorMessage({
+          title: 'Erreur',
+          message: 'Erreur inconnue lors de la copie de l’habilitation.',
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (enrollmentId) {
+      triggerReopenEnrollment({ enrollmentId });
+    }
+  }, [enrollmentId]);
+
+  if (reopennedEnrollmentId && reopennedTargetApi) {
+    return (
+      <Navigate
+        to={`/${reopennedTargetApi.replace(
+          /_/g,
+          '-'
+        )}/${reopennedEnrollmentId}`}
+        state={{ source: 'reopen-enrollment-request' }}
+        replace
+      />
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <div className="full-page">
+        <Alert title={errorMessage.title} type={AlertType.warning}>
+          <Linkify
+            message={`${errorMessage.message} L’habilitation #${enrollmentId} n’a pas été réouverte.`}
+          />
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="full-page">
+      <Loader />
+    </div>
+  );
+};
+
+export default ReopenEnrollment;

--- a/frontend/src/components/templates/UserEnrollmentList/index.tsx
+++ b/frontend/src/components/templates/UserEnrollmentList/index.tsx
@@ -10,7 +10,6 @@ import NoEnrollments from './NoEnrollments';
 import { Enrollment, Enrollment as EnrollmentType } from '../../../config';
 import { EnrollmentStatus } from '../../../config/status-parameters';
 import EnrollmentSection from '../../organisms/EnrollmentSection';
-import { isReopenned } from '../../../lib';
 
 const UserEnrollmentList = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -82,7 +81,7 @@ const UserEnrollmentList = () => {
         },
         enrollment
       ) => {
-        if (isReopenned(enrollment)) {
+        if (enrollment.reopening) {
           acc.reopenned.push(enrollment);
         } else {
           acc.notReopenned.push(enrollment);

--- a/frontend/src/components/templates/hooks/use-list-item-navigation.ts
+++ b/frontend/src/components/templates/hooks/use-list-item-navigation.ts
@@ -7,8 +7,16 @@ export const useListItemNavigation = () => {
   const navigate = useNavigate();
 
   const goToItem = useCallback(
-    (target_api: string, id: number, clickEvent?: React.MouseEvent) => {
-      const targetUrl = `/${target_api.replace(/_/g, '-')}/${id}`;
+    (
+      target_api: string,
+      id: number,
+      clickEvent?: React.MouseEvent,
+      snapshotId?: number
+    ) => {
+      const targetUrlBase = `/${target_api.replace(/_/g, '-')}/${id}`;
+      const targetUrl = snapshotId
+        ? `${targetUrlBase}/${snapshotId}`
+        : targetUrlBase;
 
       if (clickEvent?.ctrlKey || clickEvent?.metaKey) {
         // metaKey is cmd on Mac

--- a/frontend/src/config/event-configuration.tsx
+++ b/frontend/src/config/event-configuration.tsx
@@ -15,6 +15,9 @@ export enum EnrollmentEvent {
   instruct = 'instruct',
   update_contacts = 'update_contacts',
   copy = 'copy',
+  create_opinion = 'create_opinion',
+  create_opinion_comment = 'create_opinion_comment',
+  reopen = 'reopen',
 }
 
 export enum PromptType {

--- a/frontend/src/config/event-configuration.tsx
+++ b/frontend/src/config/event-configuration.tsx
@@ -1,3 +1,5 @@
+import { Enrollment } from './index';
+
 export enum EnrollmentEvent {
   notify = 'notify',
   create = 'create',
@@ -37,6 +39,7 @@ export enum RequestType {
 
 export type EventConfiguration = {
   displayProps: {
+    getLabel(enrollment: Enrollment): string;
     label: string;
     icon?: string;
     secondary?: boolean;
@@ -83,6 +86,10 @@ export const eventConfigurations: {
   },
   [EnrollmentEvent.submit]: {
     displayProps: {
+      getLabel: (enrollment: Enrollment) =>
+        enrollment.reopening
+          ? 'Soumettre la demande de mise à jour'
+          : 'Soumettre la demande d’habilitation',
       label: 'Soumettre la demande d’habilitation',
       icon: 'checkbox',
     },

--- a/frontend/src/config/index.tsx
+++ b/frontend/src/config/index.tsx
@@ -76,6 +76,8 @@ export type Event = {
   processed_at?: string;
   updated_at: string;
   user: User;
+  entity_id: number;
+  entity_type: string;
 };
 
 export enum TeamMemberType {

--- a/frontend/src/config/index.tsx
+++ b/frontend/src/config/index.tsx
@@ -154,4 +154,5 @@ export type Enrollment = {
   zip_code?: string;
   contacts?: Contact[];
   user?: User;
+  reopening?: boolean;
 };

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -21,7 +21,7 @@ import {
 import flatten from 'flat';
 import { AxiosError, AxiosResponse } from 'axios';
 import { DataProviderConfiguration } from '../config/data-provider-configurations';
-import { Enrollment, TeamMember } from '../config';
+import { Enrollment, Event, TeamMember } from '../config';
 import { EnrollmentEvent } from '../config/event-configuration';
 import { EnrollmentStatus } from '../config/status-parameters';
 
@@ -618,3 +618,6 @@ export const isUserADemandeur = ({
 export const isReopenned = (enrollment: Enrollment) =>
   enrollment.events?.some(({ name }) => name === EnrollmentEvent.reopen) &&
   enrollment.status !== EnrollmentStatus.validated;
+
+export const getLastSnapshotId = (events: Event[]) =>
+  events?.find(({ name }) => name === EnrollmentEvent.validate)?.entity_id;

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -22,6 +22,8 @@ import flatten from 'flat';
 import { AxiosError, AxiosResponse } from 'axios';
 import { DataProviderConfiguration } from '../config/data-provider-configurations';
 import { Enrollment, TeamMember } from '../config';
+import { EnrollmentEvent } from '../config/event-configuration';
+import { EnrollmentStatus } from '../config/status-parameters';
 
 interface ExtendedData {
   title?: string;
@@ -612,3 +614,7 @@ export const isUserADemandeur = ({
     .filter(({ type }) => type === 'demandeur')
     .map(({ email }) => email)
     .includes(user_email);
+
+export const isReopenned = (enrollment: Enrollment) =>
+  enrollment.events?.some(({ name }) => name === EnrollmentEvent.reopen) &&
+  enrollment.status !== EnrollmentStatus.validated;

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -23,7 +23,6 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { DataProviderConfiguration } from '../config/data-provider-configurations';
 import { Enrollment, Event, TeamMember } from '../config';
 import { EnrollmentEvent } from '../config/event-configuration';
-import { EnrollmentStatus } from '../config/status-parameters';
 
 interface ExtendedData {
   title?: string;
@@ -614,10 +613,6 @@ export const isUserADemandeur = ({
     .filter(({ type }) => type === 'demandeur')
     .map(({ email }) => email)
     .includes(user_email);
-
-export const isReopenned = (enrollment: Enrollment) =>
-  enrollment.events?.some(({ name }) => name === EnrollmentEvent.reopen) &&
-  enrollment.status !== EnrollmentStatus.validated;
 
 export const getLastSnapshotId = (events: Event[]) =>
   events?.find(({ name }) => name === EnrollmentEvent.validate)?.entity_id;

--- a/frontend/src/services/enrollments.tsx
+++ b/frontend/src/services/enrollments.tsx
@@ -291,3 +291,11 @@ export function markEventAsRead({
     )
     .then(({ data }) => data);
 }
+
+export function reopenEnrollment({ id }: { id: number }) {
+  return httpClient
+    .patch(`${BACK_HOST}/api/reopen_enrollments/${id}/`, {
+      headers: { 'Content-type': 'application/json' },
+    })
+    .then(({ data }) => data);
+}

--- a/frontend/src/services/enrollments.tsx
+++ b/frontend/src/services/enrollments.tsx
@@ -55,6 +55,25 @@ export function getUserEnrollment(id: number) {
   );
 }
 
+export function getUserEnrollmentSnapshot({
+  enrollmentId,
+  snapshotId,
+}: {
+  enrollmentId: number;
+  snapshotId: number;
+}) {
+  return httpClient
+    .get(
+      `${BACK_HOST}/api/enrollments/${enrollmentId}/validated/${snapshotId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+    .then(({ data: enrollment }) => enrollment);
+}
+
 export function hasAccessToEnrollment(id: number) {
   return getUserEnrollment(id)
     .then(() => true)


### PR DESCRIPTION
## Changements interface frontend

1. `/api/reopen_enrollments/:id` => Permet de réouvre une habilitation, et la renvoi ;
2. `/api/enrollments/:enrollment_id/validated/:id` => Permet de voir une habilitation validé. Le `id` est l'id du snapshot crée et associé à l'événement `validated`. Le commit sur le `EventSerializer` rajoute l'id/type (type == `ActiveSnapshot::Snapshot`). Ici ce qui est renvoyé est ~ish un enrollment serializé, les associations sont override avec le snapshot (cf le code)
3. L'id du snapshot est maintenant dans l'événement (comme précisé ci-dessus)

------

Y'a un GROS hack dégueu pour permettre la création du snapshot des associations, plus d'infos dans le commit.

Closes https://linear.app/pole-api/issue/DAT-161/conception-backend-reouverture-de-demande-validee