### PR TITLE
Bugfix mailbox for API Entreculier

### DIFF
--- a/backend/app/notifiers/abstract_entreculier_notifier.rb
+++ b/backend/app/notifiers/abstract_entreculier_notifier.rb
@@ -32,8 +32,15 @@ class AbstractEntreculierNotifier < AbstractNotifier
     deliver_event_webhook(__method__)
   end
 
-  def notify(*)
-    deliver_event_webhook(__method__)
+  def notify(comment:, current_user:)
+    demandeurs_ids = enrollment.demandeurs.pluck(:user_id)
+    if demandeurs_ids.include?(current_user.id)
+      deliver_message_to_enrollment_instructor(comment)
+    end
+
+    if current_user.is_instructor?(enrollment.target_api)
+      deliver_event_mailer(__method__, comment)
+    end
   end
 
   def request_changes(*)

--- a/backend/spec/notifiers/abstract_entreculier_notifier_spec.rb
+++ b/backend/spec/notifiers/abstract_entreculier_notifier_spec.rb
@@ -49,10 +49,12 @@ RSpec.describe AbstractEntreculierNotifier, type: :notifier do
     end
 
     describe "#notify" do
-      subject { instance.notify(comment: "comment", current_user: user) }
+      subject { instance.notify(comment: "comment", current_user: enrollment.demandeurs.first.user) }
 
-      include_examples "notifier webhook delivery" do
-        let(:event) { "notify" }
+      it "delivers an email" do
+        expect do
+          subject
+        end.to have_enqueued_job
       end
     end
 


### PR DESCRIPTION
Copy from BaseNotifier the `notify` method, for 2 reasons:

1. This event handles mailbox messages, which was ignored in the ApiEntreculierNotifier
2. The `notify` event is useless for API Entreculier