### PR TITLE
Lock migrated API from v1 to v2 actions

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -20,6 +20,12 @@ class Enrollment < ApplicationRecord
     def sti_name
       name.demodulize.underscore
     end
+
+    def migrated_target_apis
+      %w[
+        api_entreprise
+      ]
+    end
   end
 
   validate :update_validation

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -19,7 +19,8 @@ class EnrollmentPolicy < ApplicationPolicy
   end
 
   def update?
-    (record.status_draft? || record.status_changes_requested?) &&
+    record.class.migrated_target_apis.exclude?(record.target_api) &&
+      (record.status_draft? || record.status_changes_requested?) &&
       user.belongs_to_organization?(record) &&
       user.is_demandeur?(record)
   end

--- a/backend/app/policies/enrollment_policy.rb
+++ b/backend/app/policies/enrollment_policy.rb
@@ -12,7 +12,8 @@ class EnrollmentPolicy < ApplicationPolicy
     # note that we cannot use 'user.is_demandeur?(record)' here because team_members
     # are not persisted yet. We cannot use 'where' on team_members and we cannot
     # use team_member.user_id for comparaison since it has not been set yet.
-    record.status_draft? &&
+    record.class.migrated_target_apis.exclude?(record.target_api) &&
+      record.status_draft? &&
       user.belongs_to_organization?(record) &&
       record.team_members.any? { |t_m| t_m["type"] == "demandeur" && t_m.email == user.email }
   end

--- a/backend/app/services/abstract_enrollments_extractor.rb
+++ b/backend/app/services/abstract_enrollments_extractor.rb
@@ -15,7 +15,9 @@ class AbstractEnrollmentsExtractor
   end
 
   def query_enrollments
-    Enrollment.where(status: extract_criteria[:statuses])
+    Enrollment
+      .where(status: extract_criteria[:statuses])
+      .where.not(target_api: Enrollment.migrated_target_apis)
       .includes(:events)
       .where({
         events: {

--- a/backend/app/services/abstract_enrollments_extractor.rb
+++ b/backend/app/services/abstract_enrollments_extractor.rb
@@ -16,8 +16,8 @@ class AbstractEnrollmentsExtractor
 
   def query_enrollments
     Enrollment
-      .where(status: extract_criteria[:statuses])
       .where.not(target_api: Enrollment.migrated_target_apis)
+      .where(status: extract_criteria[:statuses])
       .includes(:events)
       .where({
         events: {

--- a/backend/spec/controllers/enrollments/create_spec.rb
+++ b/backend/spec/controllers/enrollments/create_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe EnrollmentsController, "#create", type: :controller do
       it { is_expected.to have_http_status(:unprocessable_entity) }
     end
 
+    context "with migrated target api" do
+      let(:target_api) { "api_entreprise" }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
+
     context "with api particulier as target api" do
       let(:target_api) { "api_particulier" }
 

--- a/backend/spec/controllers/enrollments/update_spec.rb
+++ b/backend/spec/controllers/enrollments/update_spec.rb
@@ -114,5 +114,12 @@ RSpec.describe EnrollmentsController, "#update", type: :controller do
         }.to change { api_r2p_enrollment.reload.additional_content }.to(api_r2p_attributes[:additional_content].transform_keys(&:to_s))
       end
     end
+
+    context "when updating migrated target api" do
+      let(:target_enrollment) { create(:enrollment, :api_entreprise, user: enrollment_creator) }
+      let(:target_enrollment_attributes) { {} }
+
+      it { is_expected.to have_http_status(:forbidden) }
+    end
   end
 end

--- a/backend/spec/services/abstract_enrollments_extractor_spec.rb
+++ b/backend/spec/services/abstract_enrollments_extractor_spec.rb
@@ -1,0 +1,32 @@
+class DummyEnrollmentsExtractors < AbstractEnrollmentsExtractor
+  def extract_from_date
+    1.year.ago
+  end
+
+  def extract_criteria
+    {
+      statuses: %w[validated],
+      included_event_names: %w[create],
+      most_recent_event_names: %w[create]
+    }
+  end
+end
+
+RSpec.describe AbstractEnrollmentsExtractor, type: :service do
+  describe "#call" do
+    subject { DummyEnrollmentsExtractors.new.call }
+
+    let!(:excluded_enrollment) { create(:enrollment, :api_entreprise, :validated) }
+    let!(:valid_enrollment) { create(:enrollment, :franceconnect, :validated) }
+
+    before do
+      Enrollment.find_each do |enrollment|
+        create(:event, enrollment: enrollment, name: "create")
+      end
+    end
+
+    it "returns only valid enrollments" do
+      expect(subject).to eq([valid_enrollment])
+    end
+  end
+end

--- a/backend/spec/services/enrollments_extractor/to_remind_before_archive_spec.rb
+++ b/backend/spec/services/enrollments_extractor/to_remind_before_archive_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe EnrollmentsExtractor::ToRemindBeforeArchive, type: :service do
     before do
       Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
 
-      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: 7.months.ago, updated_at: 6.months.ago)
+      enrollment = create(:enrollment, :api_impot_particulier_sandbox, :changes_requested, created_at: 7.months.ago, updated_at: 6.months.ago)
       create(:event, :request_changes, enrollment: enrollment, created_at: (6.months.ago + 5.days), updated_at: (6.months.ago + 5.days))
       create(:event, :update, enrollment: enrollment, created_at: 6.months.ago, updated_at: 6.months.ago)
 
-      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: 2.months.ago, updated_at: 1.month.ago)
+      enrollment = create(:enrollment, :api_impot_particulier_sandbox, :changes_requested, created_at: 2.months.ago, updated_at: 1.month.ago)
       create(:event, :request_changes, enrollment: enrollment, created_at: 1.month.ago, updated_at: 1.month.ago)
     end
 
@@ -31,7 +31,7 @@ RSpec.describe EnrollmentsExtractor::ToRemindBeforeArchive, type: :service do
     before do
       Timecop.freeze(Time.now.change(year: 2023, month: 2, day: 1))
 
-      enrollment = create(:enrollment, :api_entreprise, :validated, created_at: (9.months.ago + 5.days), updated_at: (8.months.ago + 28.days))
+      enrollment = create(:enrollment, :api_impot_particulier_sandbox, :validated, created_at: (9.months.ago + 5.days), updated_at: (8.months.ago + 28.days))
       create(:event, :create, enrollment: enrollment, created_at: (9.months.ago + 5.days), updated_at: (9.months.ago + 5.days))
       create(:event, :update, enrollment: enrollment, created_at: 9.months.ago, updated_at: 9.months.ago)
       create(:event, :submit, enrollment: enrollment, created_at: 9.months.ago, updated_at: 9.months.ago)
@@ -80,7 +80,7 @@ RSpec.describe EnrollmentsExtractor::ToRemindBeforeArchive, type: :service do
       create(:event, :request_changes, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
       create(:event, :update, enrollment: enrollment, created_at: 7.months.ago, updated_at: 7.months.ago)
 
-      enrollment = create(:enrollment, :api_entreprise, :changes_requested, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 24.days))
+      enrollment = create(:enrollment, :api_impot_particulier_sandbox, :changes_requested, created_at: (6.months.ago - 25.days), updated_at: (6.months.ago - 24.days))
       create(:event, :create, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
       create(:event, :submit, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))
       create(:event, :notify, enrollment: enrollment, created_at: (8.months.ago - 25.days), updated_at: (8.months.ago - 25.days))


### PR DESCRIPTION
Do not allow actions on migrated data

1. Introduce Enrollment.migrated_target_apis
2. No more create/update on enrollments
3. No more reminder on these migrated target APIs