### PR TITLE
Feature/dat-398 etq u je vois le meme affichage de documentation pour API IP FC et API SFIP

### DIFF
--- a/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
@@ -121,6 +121,8 @@ const DonneesSection: FunctionSectionComponent<Props> = ({
         'api_impot_particulier_unique',
         'api_impot_particulier_fc_sandbox',
         'api_impot_particulier_fc_unique',
+        'api_sfip_sandbox',
+        'api_sfip_unique',
       ].includes(target_api);
     }, [target_api]);
 

--- a/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
@@ -119,6 +119,8 @@ const DonneesSection: FunctionSectionComponent<Props> = ({
       return ![
         'api_impot_particulier_sandbox',
         'api_impot_particulier_unique',
+        'api_impot_particulier_fc_sandbox',
+        'api_impot_particulier_fc_unique',
       ].includes(target_api);
     }, [target_api]);
 


### PR DESCRIPTION
Suite aux retours de Nicolas https://linear.app/pole-api/issue/DAT-398/etq-u-je-vois-le-meme-affichage-de-documentation-pour-api-ip-et-api#comment-d0dd61fa