### PR TITLE
QuickFix when user has a mon compte pro enrollment in his homepage

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -31,7 +31,7 @@ class Enrollment < ApplicationRecord
     end
   end
 
-  default_scope { where.not(target_api: ["mon_compte_pro"]) }
+  default_scope { where.not(target_api: ["moncomptepro"]) }
 
   validate :update_validation
   validate :submit_validation, on: :submit


### PR DESCRIPTION
  - Avoid frontend to broke if a "demandeur" has an enrollment for mon compte pro in his home page.
  
 