### PR TITLE
Augmentation du temps de data_retention_period

### DIFF
--- a/backend/app/models/enrollment.rb
+++ b/backend/app/models/enrollment.rb
@@ -57,7 +57,7 @@ class Enrollment < ApplicationRecord
   validates :data_retention_period, numericality: {
     only_integer: true,
     greater_than_or_equal_to: 0,
-    less_than_or_equal_to: 999,
+    less_than_or_equal_to: 1200,
     allow_nil: true
   }
 


### PR DESCRIPTION
  - ce chiffre est a titre indicatif, si celui ci excede 36 mois, une justification juridique est demandée et peut être validée ou modifiée par l'instructeur. Faire ce changement permet de soumettre une copie d'habilitation FranceConnect demandant un temps de 1200 mois.