### PR TITLE
Retour de la branche "Feature/dat 716 modification des scopes et ajout de modeles pre remplis dans"

### DIFF
--- a/backend/app/policies/concerns/dgfip_policy_methods.rb
+++ b/backend/app/policies/concerns/dgfip_policy_methods.rb
@@ -5,11 +5,15 @@ module DgfipPolicyMethods
 
   def ficoba_permitted_scopes
     [
-      :dgfip_ficoba_etat_civil_denomination,
-      :dgfip_ficoba_adresse,
-      :dgfip_ficoba_compte,
-      :dgfip_ficoba_etablissement_bancaire,
-      :dgfip_ficoba_date
+      :dgfip_ficoba_numero_compte,
+      :dgfip_ficoba_etablissement,
+      :dgfip_ficoba_droit_compte,
+      :dgfip_ficoba_etat_civil_adresse,
+      :dgfip_ficoba_restitution_verification,
+      :dgfip_ficoba_nombre_comptes,
+      :dgfip_ficoba_iban,
+      :dgfip_ficoba_date_ouverture,
+      :dgfip_ficoba_motif_ouverture
     ]
   end
 
@@ -19,7 +23,11 @@ module DgfipPolicyMethods
       :acces_ficoba_spi,
       :acces_ficoba_siren,
       :acces_ficoba_personne_physique,
-      :acces_ficoba_personne_morale
+      :acces_ficoba_personne_morale,
+      :acces_ficoba_adresse,
+      :acces_ficoba_iban_siren,
+      :acces_ficoba_iban_personne_physique,
+      :acces_ficoba_iban_personne_morale
     ]
   end
 

--- a/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
+++ b/frontend/src/components/organisms/form-sections/DonneesSection/index.tsx
@@ -128,6 +128,14 @@ const DonneesSection: FunctionSectionComponent<Props> = ({
     }
   }, [enableFileSubmissionForScopeSelection, isFileInputExpanded, documents]);
 
+  const predefinedLabelMap: Record<string, string> = {
+    dgfip_ficoba_etat_civil_denomination: 'État civil ou dénomination',
+    dgfip_ficoba_adresse: 'Adresse',
+    dgfip_ficoba_compte: 'Désignation du compte',
+    dgfip_ficoba_etablissement_bancaire: 'Établissement bancaire',
+    dgfip_ficoba_date: 'Date',
+  };
+
   return (
     <ScrollablePanel scrollableId={SECTION_ID}>
       <h2>Les données nécessaires</h2>
@@ -178,7 +186,7 @@ const DonneesSection: FunctionSectionComponent<Props> = ({
               title="Les données suivantes ont été sélectionnées mais ne sont plus disponibles :"
               scopesConfiguration={outdatedScopes.map((value) => ({
                 value,
-                label: value,
+                label: predefinedLabelMap[value] || value,
               }))}
               scopes={zipObject(
                 outdatedScopes,

--- a/frontend/src/pages/DgfipPages/ApiFicobaProduction.tsx
+++ b/frontend/src/pages/DgfipPages/ApiFicobaProduction.tsx
@@ -23,7 +23,7 @@ const ApiFicobaProduction = () => (
     <RecetteFonctionnelleSection />
     <CadreJuridiqueSection />
     <HomologationSecuriteSection />
-    <VolumetrieSection options={[50, 100, 200]} />
+    <VolumetrieSection options={[200, 500, 750]} />
     <CguSection cguLink="/docs/cgu_api_ficoba_production.pdf" />
   </Form>
 );

--- a/frontend/src/pages/DgfipPages/ApiFicobaSandbox.tsx
+++ b/frontend/src/pages/DgfipPages/ApiFicobaSandbox.tsx
@@ -55,7 +55,7 @@ export const demarches = {
         dgfip_ficoba_droit_compte: true,
         dgfip_ficoba_etat_civil_adresse: true,
       },
-      accessModes: {
+      additional_content: {
         acces_ficoba_iban: true,
         acces_ficoba_siren: true,
         acces_ficoba_personne_physique: true,
@@ -72,7 +72,7 @@ export const demarches = {
       scopes: {
         dgfip_ficoba_restitution_verification: true,
       },
-      accessModes: {
+      additional_content: {
         acces_ficoba_iban_siren: true,
         acces_ficoba_iban_personne_physique: true,
         acces_ficoba_iban_personne_morale: true,
@@ -88,7 +88,7 @@ export const demarches = {
       scopes: {
         dgfip_ficoba_restitution_verification: true,
       },
-      accessModes: {
+      additional_content: {
         acces_ficoba_iban: true,
       },
     },
@@ -105,7 +105,7 @@ export const demarches = {
         dgfip_ficoba_droit_compte: true,
         dgfip_ficoba_etat_civil_adresse: true,
       },
-      accessModes: {
+      additional_content: {
         acces_ficoba_iban: true,
         acces_ficoba_siren: true,
         acces_ficoba_personne_physique: true,
@@ -124,7 +124,7 @@ export const demarches = {
       scopes: {
         dgfip_ficoba_nombre_comptes: true,
       },
-      accessModes: {
+      additional_content: {
         acces_ficoba_siren: true,
         acces_ficoba_personne_physique: true,
         acces_ficoba_personne_morale: true,

--- a/frontend/src/pages/DgfipPages/ApiFicobaSandbox.tsx
+++ b/frontend/src/pages/DgfipPages/ApiFicobaSandbox.tsx
@@ -9,30 +9,191 @@ import { additionalTermsOfUse } from './common';
 import DonneesSection from '../../components/organisms/form-sections/DonneesSection';
 import { DATA_PROVIDER_CONFIGURATIONS } from '../../config/data-provider-configurations';
 import PreviousEnrollmentSection from '../../components/organisms/form-sections/PreviousEnrollmentSection';
+import DemarcheSection from '../../components/organisms/form-sections/DemarcheSection';
+
+export const demarches = {
+  default: {
+    label: 'Demande libre',
+    state: {
+      intitule: '',
+      description: '',
+      data_recipients: '',
+      fondement_juridique_title: '',
+      scopes: {
+        dgfip_ficoba_numero_compte: false,
+        dgfip_ficoba_etablissement: false,
+        dgfip_ficoba_droit_compte: false,
+        dgfip_ficoba_etat_civil_adresse: false,
+        dgfip_ficoba_restitution_verification: false,
+        dgfip_ficoba_nombre_comptes: false,
+        dgfip_ficoba_iban: false,
+        dgfip_ficoba_date_ouverture: false,
+        dgfip_ficoba_motif_ouverture: false,
+      },
+      accessModes: {
+        acces_ficoba_iban: false,
+        acces_ficoba_spi: false,
+        acces_ficoba_siren: false,
+        acces_ficoba_personne_physique: false,
+        acces_ficoba_personne_morale: false,
+        acces_ficoba_adresse: false,
+        acces_ficoba_iban_siren: false,
+        acces_ficoba_iban_personne_physique: false,
+        acces_ficoba_iban_personne_morale: false,
+      },
+    },
+  },
+  recouvrement_force: {
+    label: 'Recouvrement forcé',
+    state: {
+      intitule: 'Recouvrement forcé',
+      description:
+        'FICOBA permet de restituer la liste des comptes bancaires ouverts (sans date de clôture) dont le titulaire (personne physique ou personne morale) n’est pas à jour dans le paiement de ses impôts, taxes, amendes, cotisations… A partir des données restituées, le service peut enclencher une procédure de saisie administrative à tiers détenteur (SATD).',
+      scopes: {
+        dgfip_ficoba_numero_compte: true,
+        dgfip_ficoba_etablissement: true,
+        dgfip_ficoba_droit_compte: true,
+        dgfip_ficoba_etat_civil_adresse: true,
+      },
+      accessModes: {
+        acces_ficoba_iban: true,
+        acces_ficoba_siren: true,
+        acces_ficoba_personne_physique: true,
+        acces_ficoba_personne_morale: true,
+      },
+    },
+  },
+  verification_iban_titulaire: {
+    label: 'Vérification des IBAN par rapport au titulaire du compte',
+    state: {
+      intitule: 'Vérification des IBAN avec titulaire',
+      description:
+        'FICOBA permet de vérifier la concordance entre le compte bancaire fourni par l’usager (qui demande de bénéficier d’une prestation/aide) et son identité réelle et de confirmer si le compte fourni par le titulaire est bien présent en base pour cette même personne (lutte contre l’usurpation d’identité, de faux IBAN...).',
+      scopes: {
+        dgfip_ficoba_restitution_verification: true,
+      },
+      accessModes: {
+        acces_ficoba_iban_siren: true,
+        acces_ficoba_iban_personne_physique: true,
+        acces_ficoba_iban_personne_morale: true,
+      },
+    },
+  },
+  verification__existence_iban: {
+    label: 'Vérification de l’existence de l’IBAN',
+    state: {
+      intitule: 'Vérification de l’existence de l’IBAN',
+      description:
+        'FICOBA permet de s’assurer que l’IBAN fourni  existe bien dans FICOBA, ou s’il est toujours ouvert.',
+      scopes: {
+        dgfip_ficoba_restitution_verification: true,
+      },
+      accessModes: {
+        acces_ficoba_iban: true,
+      },
+    },
+  },
+  lutte_fraude: {
+    label: 'Lutte contre la fraude',
+    state: {
+      intitule: 'Lutte contre la fraude',
+      description:
+        'FICOBA permet d’accéder à la liste des comptes détenus par un titulaire dans le cadre d’une enquête menée par une autorité compétente afin d’appréhender un fraudeur potentiel et de constituer des éléments permettant de prouver la fraude.',
+      scopes: {
+        dgfip_ficoba_numero_compte: true,
+        dgfip_ficoba_etablissement: true,
+        dgfip_ficoba_droit_compte: true,
+        dgfip_ficoba_etat_civil_adresse: true,
+      },
+      accessModes: {
+        acces_ficoba_iban: true,
+        acces_ficoba_siren: true,
+        acces_ficoba_personne_physique: true,
+        acces_ficoba_personne_morale: true,
+      },
+    },
+  },
+  controle_multi_detention: {
+    label: 'Contrôle multi-détention des produits d’épargne réglementés',
+    state: {
+      intitule: 'Contrôle multi-détention PER',
+      description:
+        'FICOBA permet aux établissements bancaires qui commercialisent des produits d’épargne réglementé (PER) de respecter leur obligation légale de vérifier quʼun épargnant qui demande lʼouverture dʼun produit dʼépargne réglementé nʼen détient pas un autre similaire dans un autre établissement.',
+      fondement_juridique_title:
+        '- Conformément au II de lʼarticle R. 221-122 du code monétaire et financier (version au 01/01/2026),  Lʼétablissement saisi de la demande dʼouverture dʼun produit dʼépargne réglementée interroge lʼadministration fiscale afin de vérifier si la personne détient déjà un produit dʼépargne réglementée de la même catégorie. Cette saisine comporte une série de données dont la liste est fixée par arrêté des ministres chargés de lʼéconomie et du budget. Il y est précisé si le client a accepté ou refusé que les informations relatives aux produits dʼépargne réglementée de la même catégorie quʼil détiendrait déjà soient communiquées à lʼétablissement de crédit. Sur demande de lʼadministration, lʼétablissement produit le contrat conclu.',
+      scopes: {
+        dgfip_ficoba_nombre_comptes: true,
+      },
+      accessModes: {
+        acces_ficoba_siren: true,
+        acces_ficoba_personne_physique: true,
+        acces_ficoba_personne_morale: true,
+        acces_ficoba_adresse: true,
+      },
+    },
+  },
+};
 
 export const scopesConfiguration = [
   {
-    value: 'dgfip_ficoba_etat_civil_denomination',
-    label: 'État civil ou dénomination',
+    value: 'dgfip_ficoba_numero_compte',
+    label: 'Numéro du compte ouvert et caractéristiques',
   },
   {
-    value: 'dgfip_ficoba_adresse',
-    label: 'Adresse',
+    value: 'dgfip_ficoba_etablissement',
+    label: 'Etablissement / Guichet bancaire / Adresse',
   },
   {
-    value: 'dgfip_ficoba_compte',
-    label: 'Désignation du compte',
-    required: true,
+    value: 'dgfip_ficoba_droit_compte',
+    label: 'Droit sur le compte et date effective',
   },
   {
-    value: 'dgfip_ficoba_etablissement_bancaire',
-    label: 'Établissement bancaire',
+    value: 'dgfip_ficoba_etat_civil_adresse',
+    label: 'État civil / Raison sociale du titulaire du compte & adresse',
   },
   {
-    value: 'dgfip_ficoba_date',
-    label: 'Date',
+    value: 'dgfip_ficoba_restitution_verification',
+    label: 'Restitution vérification (O/N) et date de clôture le cas échéant',
+  },
+  {
+    value: 'dgfip_ficoba_nombre_comptes',
+    label: 'Nombre de comptes trouvés',
+  },
+  {
+    value: 'dgfip_ficoba_iban',
+    label: 'IBAN',
+  },
+  {
+    value: 'dgfip_ficoba_date_ouverture',
+    label: 'Date dʼouverture',
+  },
+  {
+    value: 'dgfip_ficoba_motif_ouverture',
+    label: 'Motif dʼouverture',
   },
 ];
+
+export const groups = {
+  information: {
+    label: 'Informations compte',
+    scopes: [
+      'dgfip_ficoba_numero_compte',
+      'dgfip_ficoba_etablissement',
+      'dgfip_ficoba_droit_compte',
+      'dgfip_ficoba_etat_civil_adresse',
+      'dgfip_ficoba_restitution_verification',
+    ],
+  },
+  controle_multi_detention_per: {
+    label: 'Contrôles multi-détention PER',
+    scopes: [
+      'dgfip_ficoba_nombre_comptes',
+      'dgfip_ficoba_iban',
+      'dgfip_ficoba_date_ouverture',
+      'dgfip_ficoba_motif_ouverture',
+    ],
+  },
+};
 
 export const accessModes = [
   {
@@ -49,11 +210,27 @@ export const accessModes = [
   },
   {
     id: 'acces_ficoba_personne_physique',
-    label: 'via personne physique',
+    label: 'via lʼétat civil - personne physique',
   },
   {
     id: 'acces_ficoba_personne_morale',
-    label: 'via personne morale',
+    label: 'via la raison sociale - personne morale',
+  },
+  {
+    id: 'acces_ficoba_adresse',
+    label: 'via lʼadresse',
+  },
+  {
+    id: 'acces_ficoba_iban_siren',
+    label: 'via IBAN + SIREN/SIRET',
+  },
+  {
+    id: 'acces_ficoba_iban_personne_physique',
+    label: 'via IBAN + état civil - personne physique',
+  },
+  {
+    id: 'acces_ficoba_iban_personne_morale',
+    label: 'via IBAN + raison sociale - personne morale',
   },
 ];
 
@@ -134,15 +311,18 @@ const steps = [target_api, 'api_ficoba_production'];
 const ApiFicobaSandbox = () => (
   <Form
     target_api={target_api}
+    demarches={demarches}
     contactEmail={DATA_PROVIDER_CONFIGURATIONS[target_api]?.email}
     documentationUrl="https://api.gouv.fr/les-api/api_comptes_bancaires_ficoba"
   >
     <PreviousEnrollmentSection steps={steps} />
     <OrganisationSection />
+    <DemarcheSection scopesConfiguration={scopesConfiguration} />
     <DescriptionSection />
     <DonneesSection
       DonneesDescription={DonneesDescription}
       scopesConfiguration={scopesConfiguration}
+      groups={groups}
       accessModes={accessModes}
     />
     <CadreJuridiqueSection

--- a/frontend/src/pages/DgfipPages/ApiFicobaUnique.tsx
+++ b/frontend/src/pages/DgfipPages/ApiFicobaUnique.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Form from '../../components/templates/Form';
 import DescriptionSection from '../../components/organisms/form-sections/DescriptionSection';
+import DemarcheSection from '../../components/organisms/form-sections/DemarcheSection';
 import OrganisationSection from '../../components/organisms/form-sections/OrganisationSection';
 import CguSection from '../../components/organisms/form-sections/CguSection';
 import ÉquipeSection from '../../components/organisms/form-sections/ÉquipeSection';
@@ -12,8 +13,10 @@ import { DATA_PROVIDER_CONFIGURATIONS } from '../../config/data-provider-configu
 import {
   accessModes,
   CadreJuridiqueDescription,
+  demarches,
   DonneesDescription,
   scopesConfiguration,
+  groups,
 } from './ApiFicobaSandbox';
 
 const target_api = 'api_ficoba_unique';
@@ -21,14 +24,17 @@ const target_api = 'api_ficoba_unique';
 const ApiFicobaUnique = () => (
   <Form
     target_api={target_api}
+    demarches={demarches}
     contactEmail={DATA_PROVIDER_CONFIGURATIONS[target_api]?.email}
     documentationUrl="https://api.gouv.fr/les-api/api_comptes_bancaires_ficoba"
   >
     <OrganisationSection />
+    <DemarcheSection scopesConfiguration={scopesConfiguration} />
     <DescriptionSection />
     <DonneesSection
       DonneesDescription={DonneesDescription}
       scopesConfiguration={scopesConfiguration}
+      groups={groups}
       accessModes={accessModes}
     />
     <CadreJuridiqueSection
@@ -36,7 +42,7 @@ const ApiFicobaUnique = () => (
     />
     <ÉquipeSection />
     <HomologationSecuriteSection />
-    <VolumetrieSection options={[50, 100, 200]} />
+    <VolumetrieSection options={[200, 500, 750]} />
     <CguSection cguLink="/docs/cgu_api_ficoba_production.pdf" />
   </Form>
 );


### PR DESCRIPTION
Reverts betagouv/datapass#1549

Dans le cas ou on décide de ne pas faire de migration de scopes 
J'ai ajouté une modification à la vue qui permet d'afficher les labels correspondant aux anciens scopes sélectionné. 

<img width="1225" alt="Capture d’écran 2024-12-19 à 15 31 48" src="https://github.com/user-attachments/assets/dc1ecd06-da22-4232-a2ac-061682581683" />
