### PR TITLE
API INSEE: remove diffusible filter

### DIFF
--- a/backend/app/services/api_sirene.rb
+++ b/backend/app/services/api_sirene.rb
@@ -36,12 +36,11 @@ class ApiSirene < ApplicationService
     end
 
     etablissement = response.parse["etablissement"]
-    is_diffusable = etablissement["statutDiffusionEtablissement"] == "O"
 
     last_periode_etablissement = etablissement["periodesEtablissement"][0]
     etat_administratif = last_periode_etablissement["etatAdministratifEtablissement"]
 
-    if etat_administratif != "A" || !is_diffusable
+    if etat_administratif != "A"
       return {
         nom_raison_sociale: nil,
         siret: @siret,

--- a/backend/spec/services/api_sirene_spec.rb
+++ b/backend/spec/services/api_sirene_spec.rb
@@ -56,28 +56,6 @@ RSpec.describe ApiSirene, type: :service do
     end
   end
 
-  context "for a non diffusable organization" do
-    let(:siret) { "30002490800026" }
-
-    it "return siret and etat_administratif" do
-      expect(subject).to eq({
-        nom_raison_sociale: nil,
-        siret: "30002490800026",
-        denomination: nil,
-        sigle: nil,
-        adresse: nil,
-        code_postal: nil,
-        code_commune: nil,
-        libelle_commune: nil,
-        activite_principale: nil,
-        activite_principale_label: nil,
-        categorie_juridique: nil,
-        categorie_juridique_label: nil,
-        etat_administratif: "A"
-      })
-    end
-  end
-
   context "for an organization not present in INSEE database (ex: gendarmerie)" do
     let(:siret) { "15700033200013" }
 


### PR DESCRIPTION
The user or the FD can access these informations: first one is logged in with this organization, the later is an administration.

No need to filter non diffusible organizations here.